### PR TITLE
feat: Add initial Deep Learning MoDL framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,15 @@ plot(k_coords.cpu()) # Ensure plotting function can handle the trajectory format
 ### 6. Comprehensive Pipeline Examples
 
 For detailed examples of 2D and 3D reconstruction pipelines, including data generation, NUFFT setup, iterative reconstruction (CG), and L1/L2 regularized reconstruction, please see the Jupyter Notebook: `examples/recon_pipeline_demo.ipynb`.
+
+---
+## Deep Learning based Reconstruction (Experimental)
+
+ReconLib now includes experimental support for deep learning based reconstruction, starting with an implementation of a Model-based Deep Learning (MoDL) unrolled network.
+This network leverages the `NUFFTOperator` for data consistency and a learned CNN (e.g., ResNet-based) for regularization.
+Key components can be found in the `reconlib.deeplearning` module.
+
+### MoDL Example
+
+An example demonstrating the setup and use of the MoDL network for 2D image reconstruction from simulated data can be found in the Jupyter Notebook: `examples/modl_recon_demo.ipynb`.
+Training and evaluation scripts (`examples/unrolled_dl_train.py`, `examples/unrolled_dl_evaluate.py`) are also provided as starting points.

--- a/examples/modl_recon_demo.ipynb
+++ b/examples/modl_recon_demo.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MoDL Network Reconstruction Demo\n",
+    "\n",
+    "This notebook demonstrates setting up and using a Model-based Deep Learning (MoDL) network for MRI reconstruction using `reconlib`. We will focus on a 2D example for clarity and speed.\n",
+    "\n",
+    "The MoDL architecture alternates between a data consistency step (using the NUFFT operator) and a learned regularization step (a CNN denoiser)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import numpy as np\n",
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Adjust path to import from reconlib (if not installed as a package)\n",
+    "import sys\n",
+    "import os\n",
+    "if '..' not in sys.path:\n",
+    "    sys.path.append(os.path.abspath(os.path.join(os.path.dirname('__file__'), '..')))\n",
+    "\n",
+    "from reconlib.operators import NUFFTOperator\n",
+    "from reconlib.deeplearning.models.resnet_denoiser import SimpleResNetDenoiser\n",
+    "from reconlib.deeplearning.models.modl_network import MoDLNet\n",
+    "from reconlib.deeplearning.datasets import MoDLDataset\n",
+    "try:\n",
+    "    from iternufft import generate_phantom_2d, generate_radial_trajectory_2d\n",
+    "except ImportError:\n",
+    "    print(\"WARN: iternufft.py not found or not in PYTHONPATH. Using dummy data generators.\")\n",
+    "    def generate_phantom_2d(size, device='cpu'): return torch.rand((size,size), device=device) * 0.5\n",
+    "    def generate_radial_trajectory_2d(num_spokes, samples_per_spoke, device='cpu'): \n",
+    "        return (torch.rand((num_spokes*samples_per_spoke, 2), device=device) - 0.5) * np.pi"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Setup Device and Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "print(f\"Using device: {device}\")\n",
+    "\n",
+    "# 2D Example Parameters\n",
+    "image_size = 64 # Keep it small for a quick demo\n",
+    "image_shape_2d = (image_size, image_size)\n",
+    "dim = len(image_shape_2d)\n",
+    "\n",
+    "# K-space trajectory parameters (2D radial)\n",
+    "k_traj_params_2d = {'num_spokes': 32, 'samples_per_spoke': image_size}\n",
+    "\n",
+    "# NUFFT Operator parameters\n",
+    "oversamp_factor = tuple([2.0] * dim)\n",
+    "kb_J = tuple([4] * dim)\n",
+    "kb_alpha = tuple([2.34 * J for J in kb_J])\n",
+    "Ld_table = tuple([2**8] * dim) # Table oversampling\n",
+    "Kd_grid = tuple(int(N * os) for N, os in zip(image_shape_2d, oversamp_factor))\n",
+    "\n",
+    "nufft_op_params = {\n",
+    "    'oversamp_factor': oversamp_factor,\n",
+    "    'kb_J': kb_J,\n",
+    "    'kb_alpha': kb_alpha,\n",
+    "    'Ld': Ld_table,\n",
+    "    'Kd': Kd_grid,\n",
+    "    'kb_m': tuple([0.0]*dim),\n",
+    "    'n_shift': tuple([0.0]*dim)\n",
+    "}\n",
+    "\n",
+    "# MoDL Network parameters\n",
+    "denoiser_channels = 1 # Working with magnitude images for simplicity in this demo\n",
+    "denoiser_internal_channels = 32\n",
+    "denoiser_num_blocks = 2\n",
+    "modl_iterations = 3 # Number of unrolled iterations (K)\n",
+    "lambda_dc_val = 0.05\n",
+    "cg_iterations_dc = 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Create Dataset and DataLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For this demo, we'll just use one sample from the dataset\n",
+    "demo_dataset = MoDLDataset(\n",
+    "    dataset_size=1, # Just one sample for demo\n",
+    "    image_shape=image_shape_2d,\n",
+    "    k_trajectory_func=generate_radial_trajectory_2d,\n",
+    "    k_trajectory_params=k_traj_params_2d,\n",
+    "    nufft_op_params=nufft_op_params,\n",
+    "    phantom_func=generate_phantom_2d,\n",
+    "    phantom_params={'size': image_size},\n",
+    "    noise_level_kspace=0.01,\n",
+    "    device=device\n",
+    ")\n",
+    "\n",
+    "# Get the single sample\n",
+    "x0_initial, y_observed, x_true = demo_dataset[0]\n",
+    "\n",
+    "print(f\"Initial reconstruction (x0) shape: {x0_initial.shape}\")\n",
+    "print(f\"Observed k-space (y) shape: {y_observed.shape}\")\n",
+    "print(f\"Ground truth image (x_true) shape: {x_true.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Instantiate NUFFTOperator, Denoiser, and MoDLNet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NUFFT Operator (re-use the one from dataset for consistency or create new)\n",
+    "nufft_op = demo_dataset.nufft_op \n",
+    "\n",
+    "# Denoiser CNN\n",
+    "denoiser = SimpleResNetDenoiser(\n",
+    "    in_channels=denoiser_channels, \n",
+    "    out_channels=denoiser_channels,\n",
+    "    num_internal_channels=denoiser_internal_channels,\n",
+    "    num_blocks=denoiser_num_blocks\n",
+    ").to(device)\n",
+    "\n",
+    "# MoDL Network\n",
+    "modl_network = MoDLNet(\n",
+    "    nufft_op=nufft_op,\n",
+    "    denoiser_cnn=denoiser,\n",
+    "    num_iterations=modl_iterations,\n",
+    "    lambda_dc_initial=lambda_dc_val,\n",
+    "    num_cg_iterations_dc=cg_iterations_dc\n",
+    ").to(device)\n",
+    "\n",
+    "modl_network.eval() # Set to evaluation mode (as we are not training here)\n",
+    "print(\"MoDLNet instantiated.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Perform Reconstruction (Inference)\n",
+    "\n",
+    "Since we don't have a pre-trained model in this simple demo, the reconstruction will use the randomly initialized weights of the denoiser. The purpose is to show the pipeline structure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    # MoDLNet expects initial_image_x0 of shape (*image_shape) and complex\n",
+    "    # Our x0_initial is already complex and has the correct shape\n",
+    "    # If denoiser_channels=1, MoDLNet's internal denoiser call needs to handle magnitude\n",
+    "    # For this demo, we'll assume x0_initial (complex) is passed.\n",
+    "    # The SimpleResNetDenoiser expects (N,C,H,W). MoDLNet's forward currently assumes single batch and handles unsqueezing.\n",
+    "    \n",
+    "    # If denoiser expects single channel (e.g. magnitude)\n",
+    "    if denoiser_channels == 1:\n",
+    "        print(\"Note: Using magnitude of x0 as input to MoDLNet due to denoiser_channels=1\")\n",
+    "        # This is a simplification; typically complex data is fed through network parts\n",
+    "        # and denoiser might operate on real/imag channels or magnitude then recombine.\n",
+    "        # The current MoDLNet and SimpleResNetDenoiser setup might need adjustment for perfect complex handling.\n",
+    "        # For this demo, we pass complex x0, and if denoiser is 1-channel, it will likely take abs() internally or error.\n",
+    "        # Let's ensure the MoDLNet's denoiser call is robust or we adapt input here.    # For simplicity, we assume the MoDLNet's forward and internal denoiser call handle the channel logic.     # We pass the complex x0_initial that the DC block would use.\n",
+    "        reconstructed_image = modl_network(y_observed, x0_initial) \n",
+    "    else: # denoiser_channels == 2 (expects real/imag)\n",
+    "        # The current MoDLNet and denoiser setup expects the denoiser_cnn to handle the input appropriately.\n",
+    "        # If x0_initial is complex (H,W), SimpleResNetDenoiser expects (N,C,H,W). This is handled in SimpleResNetDenoiser's forward.\n",
+    "        reconstructed_image = modl_network(y_observed, x0_initial)\n",
+    "\n",
+    "print(f\"Reconstructed image shape: {reconstructed_image.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Visualize Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1, 3, figsize=(15, 5))\n",
+    "\n",
+    "axs[0].imshow(x_true.abs().cpu().numpy(), cmap='gray')\n",
+    "axs[0].set_title('Ground Truth (x_true)')\n",
+    "axs[0].axis('off')\n",
+    "\n",
+    "axs[1].imshow(x0_initial.abs().cpu().numpy(), cmap='gray')\n",
+    "axs[1].set_title('Initial Recon (A^H y)')\n",
+    "axs[1].axis('off')\n",
+    "\n",
+    "axs[2].imshow(reconstructed_image.abs().cpu().numpy(), cmap='gray')\n",
+    "axs[2].set_title('MoDL Reconstructed (Untrained)')\n",
+    "axs[2].axis('off')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Adjointness Test (from previous notebook)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"--- Adjointness Test for 2D NUFFTOperator ---\")\n",
+    "x_2d_test = torch.randn(image_shape_2d, dtype=torch.complex64, device=device)\n",
+    "y_2d_test_shape = (nufft_op.k_trajectory.shape[0],)\n",
+    "y_2d_test = torch.randn(y_2d_test_shape, dtype=torch.complex64, device=device)\n",
+    "\n",
+    "Ax_2d = nufft_op.op(x_2d_test)\n",
+    "Aty_2d = nufft_op.op_adj(y_2d_test)\n",
+    "\n",
+    "lhs_2d = torch.sum(Ax_2d * torch.conj(y_2d_test))\n",
+    "rhs_2d = torch.sum(x_2d_test * torch.conj(Aty_2d))\n",
+    "\n",
+    "print(f\"LHS (<Ax, y>): {lhs_2d.item()}\")\n",
+    "print(f\"RHS (<x, A*y>): {rhs_2d.item()}\")\n",
+    "abs_diff_2d = torch.abs(lhs_2d - rhs_2d).item()\n",
+    "rel_diff_2d = abs_diff_2d / torch.abs(lhs_2d).item() if torch.abs(lhs_2d) > 1e-9 else 0.0\n",
+    "print(f\"Absolute Difference: {abs_diff_2d:.6e}\")\n",
+    "print(f\"Relative Difference: {rel_diff_2d:.6e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12" 
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/unrolled_dl_evaluate.py
+++ b/examples/unrolled_dl_evaluate.py
@@ -1,0 +1,243 @@
+import torch
+import numpy as np
+import math
+import argparse
+import os
+import sys
+import matplotlib.pyplot as plt
+
+# Adjust path to import from reconlib
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from reconlib.operators import NUFFTOperator
+from reconlib.deeplearning.models.resnet_denoiser import SimpleResNetDenoiser
+from reconlib.deeplearning.models.modl_network import MoDLNet
+from reconlib.deeplearning.datasets import MoDLDataset # For data generation consistency
+# Assuming iternufft.py functions are accessible
+try:
+    from iternufft import generate_phantom_2d, generate_radial_trajectory_2d, \
+                          generate_phantom_3d, generate_radial_trajectory_3d
+except ImportError:
+    print("Warning: iternufft.py not found or its functions are not accessible.")
+    # Define dummy functions if iternufft is not found for script to be parsable
+    def generate_phantom_2d(size, device): return torch.zeros((size,size), device=device)
+    def generate_phantom_3d(shape, device): return torch.zeros(shape, device=device)
+    def generate_radial_trajectory_2d(**kwargs): return torch.zeros((100,2), device=kwargs.get('device','cpu'))
+    def generate_radial_trajectory_3d(**kwargs): return torch.zeros((100,3), device=kwargs.get('device','cpu'))
+
+# Basic PSNR and SSIM (structural similarity) functions for evaluation
+# For SSIM, a library like scikit-image might be preferred for a robust implementation,
+# but here's a simple version for demonstration if skimage is not a direct dependency.
+
+def psnr_torch(gt, pred, data_range=None):
+    if data_range is None:
+        data_range = gt.max() - gt.min()
+    mse = torch.mean((gt - pred) ** 2)
+    if mse == 0:
+        return float('inf')
+    return 20 * torch.log10(data_range / torch.sqrt(mse))
+
+def ssim_torch_simple(gt, pred, data_range=None, C1=0.01**2, C2=0.03**2):
+    """ Simplified SSIM for single channel images, assumes gt/pred are (H,W) """
+    if data_range is None:
+        data_range = gt.max() - gt.min()
+    
+    mu_x = torch.mean(pred)
+    mu_y = torch.mean(gt)
+    sigma_x_sq = torch.mean((pred - mu_x)**2)
+    sigma_y_sq = torch.mean((gt - mu_y)**2)
+    sigma_xy = torch.mean((pred - mu_x)*(gt - mu_y))
+    
+    ssim_num = (2*mu_x*mu_y + C1*data_range**2) * (2*sigma_xy + C2*data_range**2)
+    ssim_den = (mu_x**2 + mu_y**2 + C1*data_range**2) * (sigma_x_sq + sigma_y_sq + C2*data_range**2)
+    
+    return ssim_num / ssim_den
+
+
+def evaluate_modl_network(args):
+    device = torch.device('cuda' if torch.cuda.is_available() and args.use_cuda else 'cpu')
+    print(f"Using device: {device}")
+
+    # --- Data Setup (Similar to training, but for a test set) ---
+    if args.dim == 2:
+        image_shape = (args.image_size, args.image_size)
+        phantom_func = generate_phantom_2d
+        phantom_params = {'size': args.image_size}
+        k_traj_func = generate_radial_trajectory_2d
+        k_traj_params = {'num_spokes': args.num_spokes, 'samples_per_spoke': args.image_size}
+    elif args.dim == 3:
+        image_shape = (args.image_size // 2, args.image_size, args.image_size)
+        phantom_func = generate_phantom_3d
+        phantom_params = {'shape': image_shape}
+        k_traj_func = generate_radial_trajectory_3d
+        k_traj_params = {'num_profiles_z': args.num_profiles_z, 
+                         'num_spokes_per_profile': args.num_spokes_per_profile, 
+                         'samples_per_spoke': args.image_size,
+                         'shape': image_shape}
+    else:
+        raise ValueError("Dimension must be 2 or 3.")
+
+    oversamp_factor = tuple([args.oversamp_factor] * args.dim)
+    kb_J = tuple([args.kb_width] * args.dim)
+    kb_alpha = tuple([args.kb_alpha_scale * J for J in kb_J])
+    Ld = tuple([args.table_oversamp] * args.dim)
+    Kd = tuple(int(N * os) for N, os in zip(image_shape, oversamp_factor))
+    n_shift = tuple([0.0] * args.dim)
+
+    nufft_op_params = {
+        'oversamp_factor': oversamp_factor, 'kb_J': kb_J, 'kb_alpha': kb_alpha,
+        'Ld': Ld, 'Kd': Kd, 'kb_m': tuple([0.0]*args.dim), 'n_shift': n_shift,
+        'nufft_type_3d': 'table' if args.dim == 3 else None
+    }
+    if args.dim == 3: # Add interpolation_order for 3D NUFFT in NUFFTOperator via nufft_impl
+        nufft_op_params['interpolation_order'] = args.interpolation_order
+    
+    k_traj_fixed = k_traj_func(device=device, **k_traj_params)
+
+    # Test Dataset
+    # Using MoDLDataset to generate test samples easily
+    test_dataset_size = args.test_dataset_size
+    
+    # Ensure nufft_op_params for dataset is compatible with its NUFFTOperator
+    dataset_nufft_params = nufft_op_params.copy()
+    if args.dim == 2 and 'interpolation_order' in dataset_nufft_params:
+        del dataset_nufft_params['interpolation_order']
+    if args.dim == 2 and 'nufft_type_3d' in dataset_nufft_params:
+        del dataset_nufft_params['nufft_type_3d']
+
+    test_dataset = MoDLDataset(
+        dataset_size=test_dataset_size, image_shape=image_shape,
+        k_trajectory_func=k_traj_func, k_trajectory_params=k_traj_params,
+        nufft_op_params=dataset_nufft_params, 
+        phantom_func=phantom_func, phantom_params=phantom_params,
+        noise_level_kspace=args.noise_level, device=device
+    )
+    test_dataset.k_traj = k_traj_fixed # Ensure same trajectory as model was trained on
+    test_dataset.nufft_op.k_trajectory = k_traj_fixed
+    
+    # No DataLoader needed if evaluating one by one, or can use batch_size=1
+    
+    # --- Model Setup ---
+    model_nufft_op_params = nufft_op_params.copy()
+    if args.dim == 2 and 'interpolation_order' in model_nufft_op_params:
+        del model_nufft_op_params['interpolation_order']
+    if args.dim == 2 and 'nufft_type_3d' in model_nufft_op_params:
+        del model_nufft_op_params['nufft_type_3d']
+
+
+    nufft_op_model = NUFFTOperator(
+        k_trajectory=k_traj_fixed, image_shape=image_shape, device=device, **model_nufft_op_params
+    )
+    denoiser_channels = args.denoiser_channels
+    denoiser = SimpleResNetDenoiser(
+        in_channels=denoiser_channels, out_channels=denoiser_channels,
+        num_internal_channels=args.denoiser_internal_channels, num_blocks=args.denoiser_num_blocks
+    ).to(device)
+    
+    modl_network = MoDLNet(
+        nufft_op=nufft_op_model, denoiser_cnn=denoiser,
+        num_iterations=args.modl_iterations, lambda_dc_initial=args.lambda_dc,
+        # For evaluation, learnable_lambda is determined by the loaded model, not an arg here.
+        # num_cg_iterations_dc is part of the model architecture.
+        num_cg_iterations_dc=args.cg_iterations 
+    ).to(device)
+
+    # Load checkpoint
+    if not os.path.exists(args.checkpoint_path):
+        print(f"Error: Checkpoint path {args.checkpoint_path} does not exist.")
+        return
+    
+    modl_network.load_state_dict(torch.load(args.checkpoint_path, map_location=device))
+    modl_network.eval()
+    print(f"Loaded model from {args.checkpoint_path}")
+
+    # --- Evaluation Loop ---
+    total_psnr = 0.0
+    total_ssim = 0.0
+    
+    for i in range(test_dataset_size):
+        x0, y_observed, x_true = test_dataset[i]
+        x0, y_observed, x_true = x0.to(device), y_observed.to(device), x_true.to(device)
+
+        with torch.no_grad():
+            # MoDLNet forward pass expects single instance inputs: x0 (*image_shape), y (num_k_points,)
+            reconstructed_x = modl_network(y_observed, x0)
+
+        # Ensure reconstructed_x and x_true are on CPU for metrics/plotting if functions expect numpy
+        rec_np = reconstructed_x.abs().cpu() # Often evaluate on magnitude
+        gt_np = x_true.abs().cpu()
+        
+        current_psnr = psnr_torch(gt_np, rec_np)
+        current_ssim = ssim_torch_simple(gt_np, rec_np) # Simple SSIM for single slice
+        
+        total_psnr += current_psnr
+        total_ssim += current_ssim
+        
+        print(f"Sample {i+1}/{test_dataset_size} - PSNR: {current_psnr:.2f} dB, SSIM: {current_ssim:.4f}")
+
+        if args.save_images_dir and (i < args.num_images_to_save): # Save a few examples
+            if not os.path.exists(args.save_images_dir):
+                os.makedirs(args.save_images_dir)
+            
+            fig, axs = plt.subplots(1, 3, figsize=(15, 5))
+            if args.dim == 2:
+                axs[0].imshow(gt_np.numpy(), cmap='gray')
+                axs[0].set_title("Ground Truth")
+                axs[1].imshow(x0.abs().cpu().numpy(), cmap='gray') # Initial/Zero-filled
+                axs[1].set_title("Initial Recon (A^H y)")
+                axs[2].imshow(rec_np.numpy(), cmap='gray')
+                axs[2].set_title("MoDL Reconstructed")
+            elif args.dim == 3:
+                center_slice = gt_np.shape[0] // 2
+                axs[0].imshow(gt_np[center_slice].numpy(), cmap='gray')
+                axs[0].set_title(f"GT (Slice {center_slice})")
+                axs[1].imshow(x0.abs().cpu()[center_slice].numpy(), cmap='gray')
+                axs[1].set_title(f"A^H y (Slice {center_slice})")
+                axs[2].imshow(rec_np[center_slice].numpy(), cmap='gray')
+                axs[2].set_title(f"MoDL (Slice {center_slice})")
+            
+            for ax_ in axs: ax_.axis('off')
+            plt.savefig(os.path.join(args.save_images_dir, f"eval_sample_{i+1}.png"))
+            plt.close(fig)
+            print(f"  Saved image for sample {i+1}")
+
+    avg_psnr = total_psnr / test_dataset_size
+    avg_ssim = total_ssim / test_dataset_size
+    print(f"\nAverage PSNR over {test_dataset_size} samples: {avg_psnr:.2f} dB")
+    print(f"Average SSIM over {test_dataset_size} samples: {avg_ssim:.4f}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="MoDL Network Evaluation Script")
+    # Inherit most args from training script for consistency
+    parser.add_argument('--checkpoint_path', type=str, required=True, help="Path to trained model checkpoint (.pth)")
+    parser.add_argument('--dim', type=int, default=2, help="Dimension of NUFFT (2 or 3)")
+    parser.add_argument('--image_size', type=int, default=64, help="Base image size")
+    parser.add_argument('--test_dataset_size', type=int, default=10, help="Number of on-the-fly test samples")
+    
+    parser.add_argument('--num_spokes', type=int, default=32, help="For 2D radial: number of spokes")
+    parser.add_argument('--num_profiles_z', type=int, default=16, help="For 3D stack-of-stars: profiles in Z")
+    parser.add_argument('--num_spokes_per_profile', type=int, default=16, help="For 3D stack-of-stars: spokes per Z profile")
+    
+    parser.add_argument('--oversamp_factor', type=float, default=2.0)
+    parser.add_argument('--kb_width', type=int, default=4)
+    parser.add_argument('--kb_alpha_scale', type=float, default=2.34)
+    parser.add_argument('--table_oversamp', type=int, default=2**8)
+    parser.add_argument('--interpolation_order', type=int, default=1, help="Interpolation order for 3D table NUFFT (0 for NN, 1 for Linear)")
+    
+    parser.add_argument('--denoiser_channels', type=int, default=1)
+    parser.add_argument('--denoiser_internal_channels', type=int, default=32)
+    parser.add_argument('--denoiser_num_blocks', type=int, default=3)
+    parser.add_argument('--modl_iterations', type=int, default=5)
+    parser.add_argument('--lambda_dc', type=float, default=0.05)
+    # Learnable lambda not relevant for eval if loading checkpoint that didn't have it
+    parser.add_argument('--cg_iterations', type=int, default=3)
+    
+    parser.add_argument('--noise_level', type=float, default=0.01, help="Relative k-space noise level for test data")
+    parser.add_argument('--use_cuda', action='store_true', help="Enable CUDA if available")
+    
+    parser.add_argument('--save_images_dir', type=str, default=None, help="Directory to save example reconstructed images. If None, images are not saved.")
+    parser.add_argument('--num_images_to_save', type=int, default=3, help="Number of sample images to save if save_images_dir is provided.")
+
+    args = parser.parse_args()
+    evaluate_modl_network(args)

--- a/examples/unrolled_dl_train.py
+++ b/examples/unrolled_dl_train.py
@@ -1,0 +1,253 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+import numpy as np
+import math
+import argparse
+import os
+import sys
+
+# Adjust path to import from reconlib
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from reconlib.operators import NUFFTOperator
+from reconlib.deeplearning.models.resnet_denoiser import SimpleResNetDenoiser
+from reconlib.deeplearning.models.modl_network import MoDLNet
+from reconlib.deeplearning.datasets import MoDLDataset
+# Assuming iternufft.py functions are accessible for dataset
+try:
+    from iternufft import generate_phantom_2d, generate_radial_trajectory_2d, \
+                          generate_phantom_3d, generate_radial_trajectory_3d
+except ImportError:
+    # Define dummy functions if iternufft is not found for script to be parsable
+    print("Warning: iternufft.py not found or its functions are not accessible.")
+    def generate_phantom_2d(size, device): return torch.zeros((size,size), device=device)
+    def generate_phantom_3d(shape, device): return torch.zeros(shape, device=device)
+    def generate_radial_trajectory_2d(**kwargs): return torch.zeros((100,2), device=kwargs.get('device','cpu'))
+    def generate_radial_trajectory_3d(**kwargs): return torch.zeros((100,3), device=kwargs.get('device','cpu'))
+
+
+def train_modl_network(args):
+    device = torch.device('cuda' if torch.cuda.is_available() and args.use_cuda else 'cpu')
+    print(f"Using device: {device}")
+
+    # --- Data Setup ---
+    if args.dim == 2:
+        image_shape = (args.image_size, args.image_size)
+        phantom_func = generate_phantom_2d
+        phantom_params = {'size': args.image_size}
+        k_traj_func = generate_radial_trajectory_2d
+        k_traj_params = {'num_spokes': args.num_spokes, 'samples_per_spoke': args.image_size}
+    elif args.dim == 3:
+        image_shape = (args.image_size // 2, args.image_size, args.image_size) # Smaller Z dim
+        phantom_func = generate_phantom_3d
+        phantom_params = {'shape': image_shape}
+        k_traj_func = generate_radial_trajectory_3d
+        k_traj_params = {'num_profiles_z': args.num_profiles_z, 
+                         'num_spokes_per_profile': args.num_spokes_per_profile, 
+                         'samples_per_spoke': args.image_size,
+                         'shape': image_shape}
+    else:
+        raise ValueError("Dimension must be 2 or 3.")
+
+    # NUFFT Operator parameters (shared for dataset and model)
+    oversamp_factor = tuple([args.oversamp_factor] * args.dim)
+    kb_J = tuple([args.kb_width] * args.dim)
+    kb_alpha = tuple([args.kb_alpha_scale * J for J in kb_J]) # e.g. 2.34 * J
+    Ld = tuple([args.table_oversamp] * args.dim)
+    # Kd (oversampled grid size) can be derived by NUFFTOperator if None
+    Kd = tuple(int(N * os) for N, os in zip(image_shape, oversamp_factor))
+    n_shift = tuple([0.0] * args.dim)
+
+
+    nufft_op_params = {
+        'oversamp_factor': oversamp_factor,
+        'kb_J': kb_J,
+        'kb_alpha': kb_alpha,
+        'Ld': Ld,
+        'Kd': Kd,
+        'kb_m': tuple([0.0]*args.dim), # Default m=0
+        'n_shift': n_shift,
+        'nufft_type_3d': 'table' if args.dim == 3 else None # Relevant for NUFFTOperator
+    }
+    if args.dim == 3: # Add interpolation_order for 3D NUFFT in NUFFTOperator via nufft_impl
+        nufft_op_params['interpolation_order'] = args.interpolation_order
+    
+    # Create k-trajectory for NUFFTOperator (used by MoDLNet and Dataset)
+    # This k-trajectory is fixed for all data items in this basic setup
+    k_traj_fixed = k_traj_func(device=device, **k_traj_params)
+
+    # Dataset and DataLoader
+    # Pass all nufft_op_params to dataset which will create its own NUFFTOperator
+    dataset_nufft_params = nufft_op_params.copy()
+    if args.dim == 2 and 'interpolation_order' in dataset_nufft_params: # NUFFT2D doesn't take this
+        del dataset_nufft_params['interpolation_order']
+    if args.dim == 2 and 'nufft_type_3d' in dataset_nufft_params:
+        del dataset_nufft_params['nufft_type_3d']
+
+
+    modl_dataset = MoDLDataset(
+        dataset_size=args.dataset_size,
+        image_shape=image_shape,
+        k_trajectory_func=k_traj_func, # Will re-generate, but NUFFTOp in dataset will use its own k_traj_fixed
+        k_trajectory_params=k_traj_params, # So this is somewhat redundant here if dataset uses fixed op
+        nufft_op_params=dataset_nufft_params,   # Pass all params for dataset's internal NUFFTOperator
+        phantom_func=phantom_func,
+        phantom_params=phantom_params,
+        noise_level_kspace=args.noise_level,
+        device=device
+    )
+    # Override the dataset's nufft_op.k_trajectory if we want it truly fixed from outside
+    # This ensures the k_trajectory is identical for all samples if k_traj_func has randomness
+    modl_dataset.k_traj = k_traj_fixed 
+    modl_dataset.nufft_op.k_trajectory = k_traj_fixed 
+
+
+    dataloader = DataLoader(modl_dataset, batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers)
+
+    # --- Model Setup ---
+    # NUFFT Operator for the MoDL network
+    model_nufft_op_params = nufft_op_params.copy()
+    if args.dim == 2 and 'interpolation_order' in model_nufft_op_params:
+        del model_nufft_op_params['interpolation_order']
+    if args.dim == 2 and 'nufft_type_3d' in model_nufft_op_params: # NUFFT2D doesn't use this
+        del model_nufft_op_params['nufft_type_3d']
+
+
+    nufft_op_model = NUFFTOperator(
+        k_trajectory=k_traj_fixed, # Use the same fixed trajectory
+        image_shape=image_shape,
+        device=device,
+        **model_nufft_op_params
+    )
+
+    # Denoiser CNN
+    denoiser_channels = args.denoiser_channels 
+    if args.dim == 3 and denoiser_channels <=2: # Assuming denoiser_channels=1 for mag, 2 for real/imag complex
+        print("Warning: Using a 2D-style denoiser (in_channels<=2) for 3D data. Ensure denoiser is 3D compatible or processes slices.")
+    
+    denoiser = SimpleResNetDenoiser(
+        in_channels=denoiser_channels, 
+        out_channels=denoiser_channels,
+        num_internal_channels=args.denoiser_internal_channels,
+        num_blocks=args.denoiser_num_blocks
+    ).to(device)
+
+    # MoDL Network
+    modl_network = MoDLNet(
+        nufft_op=nufft_op_model,
+        denoiser_cnn=denoiser,
+        num_iterations=args.modl_iterations,
+        lambda_dc_initial=args.lambda_dc,
+        learnable_lambda_dc=args.learnable_lambda,
+        num_cg_iterations_dc=args.cg_iterations
+    ).to(device)
+
+    # --- Training ---
+    criterion = nn.MSELoss() 
+    optimizer = optim.Adam(modl_network.parameters(), lr=args.lr)
+
+    print(f"Starting training for {args.epochs} epochs...")
+    for epoch in range(args.epochs):
+        modl_network.train()
+        epoch_loss = 0.0
+        for i, (x0_batch, y_observed_batch, x_true_batch) in enumerate(dataloader):
+            # Current MoDLDataset and MoDLNet are designed for single instance (batch_size=1 implicitly)
+            # If batch_size > 1, we loop through the batch. This is inefficient.
+            # A truly batched implementation would require NUFFTOperator and MoDLNet to handle batch dims.
+            
+            current_batch_size = x0_batch.shape[0]
+            batch_loss = 0.0
+
+            for b_idx in range(current_batch_size):
+                x0, y_observed, x_true = x0_batch[b_idx], y_observed_batch[b_idx], x_true_batch[b_idx]
+                x0, y_observed, x_true = x0.to(device), y_observed.to(device), x_true.to(device)
+
+                # Prepare x_true for loss calculation based on denoiser output type
+                if denoiser_channels == 2: # Denoiser outputs 2 channels (real/imag)
+                    x_true_for_loss = torch.stack([x_true.real, x_true.imag], dim=0) # Shape (2, *spatial_dims)
+                elif denoiser_channels == 1: # Denoiser outputs 1 channel (e.g. magnitude)
+                    x_true_for_loss = torch.abs(x_true).unsqueeze(0) # Shape (1, *spatial_dims)
+                else: # Should match denoiser output format if more complex
+                    x_true_for_loss = x_true 
+                
+                optimizer.zero_grad()
+                
+                # MoDLNet.forward expects initial_image_x0 to be (*image_shape), complex.
+                reconstructed_x = modl_network(y_observed, x0) # x0 is complex from dataset
+
+                # Prepare reconstructed_x for loss calculation
+                if denoiser_channels == 2:
+                    # If denoiser output is 2-channel real/imag, and MoDLNet returns complex, convert
+                    reconstructed_x_for_loss = torch.stack([reconstructed_x.real, reconstructed_x.imag], dim=0)
+                elif denoiser_channels == 1:
+                    reconstructed_x_for_loss = torch.abs(reconstructed_x).unsqueeze(0)
+                else:
+                    reconstructed_x_for_loss = reconstructed_x
+
+                loss = criterion(reconstructed_x_for_loss, x_true_for_loss)
+                loss.backward()
+                batch_loss += loss.item()
+            
+            optimizer.step() # Step after processing the entire batch (or mini-batch)
+            epoch_loss += (batch_loss / current_batch_size)
+
+
+            if (i + 1) % args.log_interval == 0:
+                print(f"Epoch [{epoch+1}/{args.epochs}], Step [{i+1}/{len(dataloader)}], Avg Item Loss: {loss.item():.4f}") # loss.item() is last item's loss
+
+        avg_epoch_loss = epoch_loss / len(dataloader)
+        print(f"Epoch [{epoch+1}/{args.epochs}] completed. Average Epoch Loss: {avg_epoch_loss:.4f}")
+
+        if (epoch + 1) % args.save_interval == 0:
+            if not os.path.exists(args.checkpoint_dir):
+                os.makedirs(args.checkpoint_dir)
+            save_path = os.path.join(args.checkpoint_dir, f"modl_recon_epoch_{epoch+1}.pth")
+            torch.save(modl_network.state_dict(), save_path)
+            print(f"Saved model checkpoint to {save_path}")
+
+    print("Training finished.")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="MoDL Network Training Script")
+    # Data params
+    parser.add_argument('--dim', type=int, default=2, help="Dimension of NUFFT (2 or 3)")
+    parser.add_argument('--image_size', type=int, default=64, help="Base image size (e.g., 64 for 64x64 or for 3D like 32x64x64)")
+    parser.add_argument('--dataset_size', type=int, default=100, help="Number of on-the-fly samples for dataset")
+    # K-traj params (specific to example generators)
+    parser.add_argument('--num_spokes', type=int, default=32, help="For 2D radial: number of spokes")
+    parser.add_argument('--num_profiles_z', type=int, default=16, help="For 3D stack-of-stars: profiles in Z")
+    parser.add_argument('--num_spokes_per_profile', type=int, default=16, help="For 3D stack-of-stars: spokes per Z profile")
+    # NUFFT params
+    parser.add_argument('--oversamp_factor', type=float, default=2.0, help="NUFFT oversampling factor")
+    parser.add_argument('--kb_width', type=int, default=4, help="Kaiser-Bessel kernel width (J)")
+    parser.add_argument('--kb_alpha_scale', type=float, default=2.34, help="Scale for KB alpha (alpha = scale * J)")
+    parser.add_argument('--table_oversamp', type=int, default=2**8, help="Table oversampling factor (Ld)")
+    parser.add_argument('--interpolation_order', type=int, default=1, help="Interpolation order for 3D table NUFFT (0 for NN, 1 for Linear)")
+    # MoDL params
+    parser.add_argument('--denoiser_channels', type=int, default=1, help="Channels for denoiser (1 for mag, 2 for complex as real/imag)")
+    parser.add_argument('--denoiser_internal_channels', type=int, default=32, help="Internal channels in denoiser")
+    parser.add_argument('--denoiser_num_blocks', type=int, default=3, help="Number of ResNet blocks in denoiser")
+    parser.add_argument('--modl_iterations', type=int, default=5, help="Number of MoDL unrolled iterations (K)")
+    parser.add_argument('--lambda_dc', type=float, default=0.05, help="Lambda for data consistency term")
+    parser.add_argument('--learnable_lambda', action='store_true', help="Make lambda_dc learnable")
+    parser.add_argument('--cg_iterations', type=int, default=3, help="Number of CG iterations in DC step")
+    # Training params
+    parser.add_argument('--epochs', type=int, default=10, help="Number of training epochs")
+    parser.add_argument('--batch_size', type=int, default=1, help="Batch size") # Changed from 1 to allow user setting
+    parser.add_argument('--lr', type=float, default=1e-3, help="Learning rate")
+    parser.add_argument('--noise_level', type=float, default=0.01, help="Relative k-space noise level")
+    parser.add_argument('--log_interval', type=int, default=10, help="Log training loss every N steps")
+    parser.add_argument('--save_interval', type=int, default=5, help="Save checkpoint every N epochs")
+    parser.add_argument('--checkpoint_dir', type=str, default='./modl_checkpoints', help="Directory to save checkpoints")
+    parser.add_argument('--num_workers', type=int, default=0, help="Num workers for DataLoader (0 for main process)")
+    parser.add_argument('--use_cuda', action='store_true', help="Enable CUDA if available")
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.checkpoint_dir):
+        os.makedirs(args.checkpoint_dir)
+
+    train_modl_network(args)

--- a/reconlib/deeplearning/__init__.py
+++ b/reconlib/deeplearning/__init__.py
@@ -1,0 +1,14 @@
+"""
+ReconLib Deep Learning Module.
+
+This module provides components for building and training deep learning models
+for MRI reconstruction, particularly unrolled networks like MoDL.
+
+Modules:
+- models: Contains network architectures (e.g., denoisers, unrolled networks).
+- layers: Custom layers used in DL models (e.g., data consistency).
+- losses: Custom loss functions (if any).
+- utils: Utility functions for DL data handling.
+- datasets: PyTorch Dataset classes for DL training.
+"""
+pass

--- a/reconlib/deeplearning/datasets.py
+++ b/reconlib/deeplearning/datasets.py
@@ -1,0 +1,189 @@
+""" PyTorch Dataset classes for MRI reconstruction deep learning models. """
+import torch
+from torch.utils.data import Dataset
+import numpy as np
+import math
+# Adjust path for reconlib components
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from reconlib.operators import NUFFTOperator
+# Assuming iternufft.py is at the root or accessible in PYTHONPATH
+# For robust import, iternufft's functions might need to be part of reconlib proper
+try:
+    from iternufft import generate_phantom_2d, generate_phantom_3d, generate_radial_trajectory_2d, generate_radial_trajectory_3d
+except ImportError:
+    print("ERROR: iternufft.py not found. Ensure it's in the PYTHONPATH or its functions are part of reconlib.")
+    # Define dummy functions if iternufft is not found, so module can load for inspection
+    def generate_phantom_2d(size, device): return torch.zeros((size,size), device=device)
+    def generate_phantom_3d(shape, device): return torch.zeros(shape, device=device)
+    def generate_radial_trajectory_2d(num_spokes, samples_per_spoke, device): return torch.zeros((num_spokes*samples_per_spoke, 2), device=device)
+    def generate_radial_trajectory_3d(num_profiles_z, num_spokes_per_profile, samples_per_spoke, shape, device): return torch.zeros((num_profiles_z*num_spokes_per_profile*samples_per_spoke, 3), device=device)
+
+
+class MoDLDataset(Dataset):
+    """
+    A PyTorch Dataset for training MoDL or other unrolled networks.
+    Generates data on-the-fly:
+    - Ground truth image (phantom)
+    - Undersampled k-space data (using NUFFTOperator)
+    - Initial reconstruction (zero-filled via NUFFTOperator.op_adj)
+    """
+    def __init__(self,
+                 dataset_size: int,
+                 image_shape: tuple[int, ...],
+                 # NUFFTOperator parameters (passed directly or used to create one)
+                 k_trajectory_func, # Function to generate k-space trajectory, e.g., generate_radial_trajectory_2d
+                 k_trajectory_params: dict, # Params for k_trajectory_func
+                 nufft_op_params: dict,     # Params for NUFFTOperator constructor (oversamp_factor, kb_J, etc.)
+                 phantom_func, # Function to generate phantom, e.g., generate_phantom_2d
+                 phantom_params: dict, # Params for phantom_func
+                 noise_level_kspace: float = 0.00, # Relative noise level to add to k-space
+                 device: str | torch.device = 'cpu'
+                ):
+        self.dataset_size = dataset_size
+        self.image_shape = image_shape
+        self.dim = len(image_shape)
+        
+        self.k_trajectory_func = k_trajectory_func
+        self.k_trajectory_params = k_trajectory_params
+        self.nufft_op_params = nufft_op_params
+        self.phantom_func = phantom_func
+        self.phantom_params = phantom_params
+        self.noise_level_kspace = noise_level_kspace
+        self.device = torch.device(device)
+
+        # Generate a representative k-trajectory once for operator instantiation
+        # This assumes the trajectory structure is fixed for all samples, 
+        # though specific points could vary if k_trajectory_func had randomness without fixed seed.
+        # For simplicity, we generate one trajectory here.
+        self.k_traj = self.k_trajectory_func(device=self.device, **self.k_trajectory_params)
+        
+        self.nufft_op = NUFFTOperator(
+            k_trajectory=self.k_traj,
+            image_shape=self.image_shape,
+            device=self.device,
+            **self.nufft_op_params
+        )
+        print(f"MoDLDataset initialized with {self.dim}D NUFFT operator on {self.device}.")
+        if self.dim == 2 and self.k_traj.shape[-1] != 2:
+             raise ValueError("2D dataset, but k_traj last dim is not 2")
+        if self.dim == 3 and self.k_traj.shape[-1] != 3:
+             raise ValueError("3D dataset, but k_traj last dim is not 3")
+
+
+    def __len__(self) -> int:
+        return self.dataset_size
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Returns:
+            initial_recon_x0 (torch.Tensor): Initial reconstruction (e.g., A^H y). Shape: image_shape.
+            k_space_observed_y (torch.Tensor): Undersampled k-space data. Shape: (num_k_points,).
+            ground_truth_image_x_true (torch.Tensor): Fully sampled reference image. Shape: image_shape.
+        """
+        # 1. Generate ground truth image (phantom)
+        # Add seed if phantom_func supports it for reproducibility, or handle randomness if desired
+        current_phantom_params = self.phantom_params.copy()
+        if 'size' in current_phantom_params and self.dim == 2: # For generate_phantom_2d
+            current_phantom_params['size'] = self.image_shape[0] # Assuming square for 2D
+        elif 'shape' in current_phantom_params and self.dim == 3: # For generate_phantom_3d
+            current_phantom_params['shape'] = self.image_shape
+            
+        x_true = self.phantom_func(device=self.device, **current_phantom_params).to(torch.complex64)
+
+        # 2. Simulate undersampled k-space data: y = A(x_true) + noise
+        y_clean = self.nufft_op.op(x_true)
+        
+        if self.noise_level_kspace > 0:
+            # Add complex Gaussian noise
+            noise_std_val = self.noise_level_kspace * torch.mean(torch.abs(y_clean))
+            noise = noise_std_val * (torch.randn_like(y_clean.real) + 1j * torch.randn_like(y_clean.real))
+            y_observed = y_clean + noise
+        else:
+            y_observed = y_clean
+            
+        # 3. Compute initial reconstruction: x0 = A^H(y_observed)
+        # Note: NUFFTOperator.op_adj already includes scaling factor for adjoint.
+        # DCF should be applied to y_observed if NUFFT2D/3D adjoint expects it (current NUFFT2D does, NUFFT3D user applies)
+        # For MoDL, A^H y is part of the DC step, so x0 can be simpler.
+        # Often, x0 is just A^H y without explicit DCF for the *initial* input to network.
+        # Let's provide A^H y. If NUFFT2D applies DCF internally in its op_adj, it will be applied.
+        x0 = self.nufft_op.op_adj(y_observed)
+        
+        return x0, y_observed, x_true
+
+
+if __name__ == '__main__':
+    print("Testing MoDLDataset...")
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    # --- 2D Dataset Test ---
+    print("\n--- Testing 2D MoDLDataset ---")
+    image_shape_2d = (64, 64)
+    k_traj_params_2d = {'num_spokes': 32, 'samples_per_spoke': 64}
+    
+    nufft_op_params_2d = {
+        'oversamp_factor': (2.0, 2.0),
+        'kb_J': (4, 4),
+        'kb_alpha': tuple(2.34 * J for J in (4,4)),
+        'Ld': (2**8, 2**8)
+    }
+    phantom_params_2d = {'size': image_shape_2d[0]} # For generate_phantom_2d
+
+    dataset_2d = MoDLDataset(
+        dataset_size=4,
+        image_shape=image_shape_2d,
+        k_trajectory_func=generate_radial_trajectory_2d,
+        k_trajectory_params=k_traj_params_2d,
+        nufft_op_params=nufft_op_params_2d,
+        phantom_func=generate_phantom_2d,
+        phantom_params=phantom_params_2d,
+        noise_level_kspace=0.01,
+        device=device
+    )
+    
+    x0_2d, y_2d, xt_2d = dataset_2d[0]
+    print(f"2D Example shapes: x0: {x0_2d.shape}, y: {y_2d.shape}, x_true: {xt_2d.shape}")
+    assert x0_2d.shape == image_shape_2d
+    assert xt_2d.shape == image_shape_2d
+    assert y_2d.ndim == 1
+
+    # --- 3D Dataset Test ---
+    print("\n--- Testing 3D MoDLDataset ---")
+    image_shape_3d = (16, 32, 32) # Small for test
+    k_traj_params_3d = {
+        'num_profiles_z': 16, 
+        'num_spokes_per_profile': 16, 
+        'samples_per_spoke': 32,
+        'shape': image_shape_3d 
+    }
+    nufft_op_params_3d = {
+        'oversamp_factor': (1.5, 1.5, 1.5),
+        'kb_J': (4, 4, 4),
+        'kb_alpha': tuple(2.34 * J for J in (4,4,4)),
+        'Ld': (2**6, 2**6, 2**6), # Smaller table for faster test
+        'nufft_type_3d': 'table' # Explicitly use table for 3D
+    }
+    phantom_params_3d = {'shape': image_shape_3d}
+
+    dataset_3d = MoDLDataset(
+        dataset_size=2,
+        image_shape=image_shape_3d,
+        k_trajectory_func=generate_radial_trajectory_3d,
+        k_trajectory_params=k_traj_params_3d,
+        nufft_op_params=nufft_op_params_3d,
+        phantom_func=generate_phantom_3d,
+        phantom_params=phantom_params_3d,
+        noise_level_kspace=0.01,
+        device=device
+    )
+
+    x0_3d, y_3d, xt_3d = dataset_3d[0]
+    print(f"3D Example shapes: x0: {x0_3d.shape}, y: {y_3d.shape}, x_true: {xt_3d.shape}")
+    assert x0_3d.shape == image_shape_3d
+    assert xt_3d.shape == image_shape_3d
+    assert y_3d.ndim == 1
+    
+    print("\nMoDLDataset basic tests completed.")

--- a/reconlib/deeplearning/layers/__init__.py
+++ b/reconlib/deeplearning/layers/__init__.py
@@ -1,0 +1,2 @@
+""" Custom Deep Learning Layers for ReconLib Models. """
+pass

--- a/reconlib/deeplearning/layers/data_consistency.py
+++ b/reconlib/deeplearning/layers/data_consistency.py
@@ -1,0 +1,184 @@
+import torch
+import torch.nn as nn
+# Adjust path if NUFFTOperator is not directly importable
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))) # Go up three levels for reconlib
+from reconlib.operators import NUFFTOperator # Assuming NUFFTOperator is in reconlib.operators
+
+class DataConsistencyMoDL(nn.Module):
+    """
+    MoDL Data Consistency block.
+    Solves: (A^H A + lambda I) x = A^H y + lambda z
+    where A is the NUFFTOperator, y is observed k-space, z is denoiser output.
+    The solution is found using Conjugate Gradient.
+    """
+    def __init__(self, 
+                 nufft_op: NUFFTOperator, 
+                 lambda_dc: float | torch.Tensor, 
+                 num_cg_iterations: int = 5):
+        super().__init__()
+        self.nufft_op = nufft_op
+        if isinstance(lambda_dc, float):
+            # If float, make it a non-trainable buffer.
+            # If it needs to be learnable, it should be passed as a Parameter.
+            self.lambda_dc = torch.tensor(lambda_dc, device=nufft_op.device, dtype=torch.float32) 
+        elif isinstance(lambda_dc, torch.Tensor):
+            if lambda_dc.numel() == 1:
+                self.lambda_dc = lambda_dc.to(device=nufft_op.device, dtype=torch.float32)
+            else:
+                raise ValueError("lambda_dc tensor must be a scalar.")
+        else:
+            raise TypeError("lambda_dc must be float or torch.Tensor scalar.")
+
+        self.num_cg_iterations = num_cg_iterations
+        self.device = nufft_op.device
+        self.image_shape = nufft_op.image_shape
+
+    def _cg_solve(self, b: torch.Tensor, max_iter: int, tol: float = 1e-5) -> torch.Tensor:
+        """
+        Solves (A^H A + lambda I) x = b using Conjugate Gradient.
+        A is self.nufft_op.
+        lambda is self.lambda_dc.
+        b is the right hand side.
+        """
+        x = torch.zeros_like(b) # Initial guess for image domain solution
+        r = b - self.operator_AHA_plus_lambda_I(x) # Initial residual: b - (A^H A + lambda I)x
+        p = r.clone()
+        rs_old = torch.sum(torch.conj(r) * r).real
+
+        for i in range(max_iter):
+            Ap = self.operator_AHA_plus_lambda_I(p)
+            alpha_num = rs_old
+            alpha_den = torch.sum(torch.conj(p) * Ap).real
+            
+            if torch.abs(alpha_den) < 1e-12: # Avoid division by zero or very small denominator
+                # print(f"CG iter {i+1}, Denominator too small, stopping.")
+                break
+            alpha = alpha_num / alpha_den
+            
+            x = x + alpha * p
+            r = r - alpha * Ap
+            rs_new = torch.sum(torch.conj(r) * r).real
+            
+            if torch.sqrt(rs_new) < tol:
+                # print(f"CG iter {i+1}, Residual below tolerance {tol}, stopping.")
+                break
+            
+            p = r + (rs_new / rs_old) * p
+            rs_old = rs_new
+            
+            # if i == max_iter -1:
+            #     print(f"CG warning: Max iterations ({max_iter}) reached. Residual: {torch.sqrt(rs_new):.2e}")
+
+        return x
+
+    def operator_AHA_plus_lambda_I(self, image_estimate: torch.Tensor) -> torch.Tensor:
+        """ Computes (A^H A + lambda I)x """
+        # A x
+        kspace_estimate = self.nufft_op.op(image_estimate)
+        # A^H (A x)
+        aha_x = self.nufft_op.op_adj(kspace_estimate)
+        # (A^H A + lambda I) x
+        return aha_x + self.lambda_dc * image_estimate
+
+    def forward(self, 
+                current_image_estimate_zk: torch.Tensor, # Output of denoiser (z_k)
+                observed_k_space_y: torch.Tensor         # Original undersampled k-space (y)
+               ) -> torch.Tensor:                       # Returns x_{k+1}
+        """
+        current_image_estimate_zk: Current estimate from denoiser (z_k in MoDL paper). Shape: self.image_shape
+        observed_k_space_y: Acquired k-space data. Shape: (num_k_points,)
+        """
+        if current_image_estimate_zk.shape != self.image_shape:
+            raise ValueError(f"Shape of current_image_estimate_zk {current_image_estimate_zk.shape} must match {self.image_shape}")
+        if observed_k_space_y.device != self.device:
+            observed_k_space_y = observed_k_space_y.to(self.device)
+        if current_image_estimate_zk.device != self.device:
+            current_image_estimate_zk = current_image_estimate_zk.to(self.device)
+
+        # Compute right hand side: b = A^H y + lambda * z_k
+        Aty = self.nufft_op.op_adj(observed_k_space_y)
+        rhs_b = Aty + self.lambda_dc * current_image_estimate_zk
+        
+        # Solve (A^H A + lambda I) x = b using CG
+        # Initial guess for x can be current_image_estimate_zk or zeros
+        # Using zeros as initial guess for CG solver for system Ax=b
+        solved_image_xk_plus_1 = self._cg_solve(rhs_b, max_iter=self.num_cg_iterations)
+        
+        return solved_image_xk_plus_1
+
+if __name__ == '__main__':
+    # This is a placeholder for a proper test, which should be in tests/
+    print("Running DataConsistencyMoDL basic example...")
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    # Setup a dummy NUFFTOperator (requires reconlib.nufft to be available)
+    # For this standalone test, we might need to mock NUFFTOperator if reconlib.nufft is complex to setup
+    # Or use a simplified version if possible.
+    # Let's assume NUFFTOperator can be instantiated simply for shape purposes here.
+    
+    # Mocking NUFFTOperator for the sake of this example if reconlib.nufft is not easily accessible
+    class MockNUFFTOperator:
+        def __init__(self, image_shape, k_traj_len, device_):
+            self.image_shape = image_shape
+            self.k_trajectory = torch.zeros(k_traj_len, len(image_shape)) # Dummy
+            self.device = device_
+        def op(self, x): # A
+            # Simulate forward: image -> k-space
+            # For test, just return sum of pixels for each k-point (wrong but gives shape)
+            return torch.ones(self.k_trajectory.shape[0], dtype=x.dtype, device=x.device) * torch.sum(x)
+        def op_adj(self, y): # A_H
+            # Simulate adjoint: k-space -> image
+            # For test, just broadcast sum of k-space to image shape (wrong but gives shape)
+            return torch.ones(self.image_shape, dtype=y.dtype, device=y.device) * torch.sum(y)
+
+    img_s = 32
+    k_pts = 100
+    dims = 2
+    if dims == 2:
+        ishape = (img_s, img_s)
+    else:
+        ishape = (img_s//2, img_s, img_s)
+
+    try:
+        # Attempt to use the real NUFFTOperator if reconlib is structured for it
+        from reconlib.operators import NUFFTOperator # Ensure this path is correct
+        
+        # Minimal params for NUFFTOperator
+        k_traj_dummy = torch.rand(k_pts, dims, device=device) - 0.5
+        oversamp_factor_dummy = tuple([2.0]*dims)
+        kb_J_dummy = tuple([4]*dims)
+        kb_alpha_dummy = tuple([2.34 * J for J in kb_J_dummy])
+        Ld_dummy = tuple([2**8]*dims)
+
+        nufft_op_mock = NUFFTOperator(
+            image_shape=ishape,
+            k_trajectory=k_traj_dummy,
+            oversamp_factor=oversamp_factor_dummy,
+            kb_J=kb_J_dummy,
+            kb_alpha=kb_alpha_dummy,
+            Ld=Ld_dummy,
+            device=device
+        )
+        print("Using actual NUFFTOperator for test.")
+    except Exception as e:
+        print(f"Could not init actual NUFFTOperator ({e}), using MockNUFFTOperator for DataConsistencyMoDL example.")
+        nufft_op_mock = MockNUFFTOperator(image_shape=ishape, k_traj_len=k_pts, device_=device)
+
+
+    lambda_val = 0.05
+    dc_layer = DataConsistencyMoDL(nufft_op=nufft_op_mock, lambda_dc=lambda_val, num_cg_iterations=3).to(device)
+
+    # Dummy data
+    z_k = torch.randn(ishape, dtype=torch.complex64, device=device)
+    y_k_space = torch.randn(k_pts, dtype=torch.complex64, device=device)
+
+    print(f"Input z_k shape: {z_k.shape}")
+    print(f"Input y_k_space shape: {y_k_space.shape}")
+
+    # Run forward pass
+    x_k_plus_1 = dc_layer(z_k, y_k_space)
+    print(f"Output x_k_plus_1 shape: {x_k_plus_1.shape}")
+    assert x_k_plus_1.shape == ishape, "Output shape mismatch!"
+    print("DataConsistencyMoDL basic example run completed.")

--- a/reconlib/deeplearning/losses/__init__.py
+++ b/reconlib/deeplearning/losses/__init__.py
@@ -1,0 +1,2 @@
+""" Custom Loss Functions for Training ReconLib DL Models. """
+pass

--- a/reconlib/deeplearning/losses/common_losses.py
+++ b/reconlib/deeplearning/losses/common_losses.py
@@ -1,0 +1,2 @@
+# Placeholder for Common Loss functions
+pass

--- a/reconlib/deeplearning/models/__init__.py
+++ b/reconlib/deeplearning/models/__init__.py
@@ -1,0 +1,2 @@
+""" Deep Learning Model Architectures for ReconLib. """
+pass

--- a/reconlib/deeplearning/models/modl_network.py
+++ b/reconlib/deeplearning/models/modl_network.py
@@ -1,0 +1,232 @@
+import torch
+import torch.nn as nn
+# Adjust paths as necessary
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))) # Go up three levels for reconlib
+
+from reconlib.operators import NUFFTOperator
+# Assuming ResNetDenoiser is in a sibling directory 'models' if this file is also in 'models'
+# If this file (modl_network.py) is in reconlib/deeplearning/models, then:
+from .resnet_denoiser import SimpleResNetDenoiser 
+# And DataConsistencyMoDL is in reconlib/deeplearning/layers:
+from ..layers.data_consistency import DataConsistencyMoDL 
+
+
+class MoDLNet(nn.Module):
+    """
+    MoDL (Model-based Deep Learning) network for MRI reconstruction.
+    This network unrolls an iterative optimization algorithm that alternates between
+    a learned regularization (denoising via CNN) and data consistency steps.
+    """
+    def __init__(self,
+                 nufft_op: NUFFTOperator,
+                 denoiser_cnn: nn.Module, # Pass an instance of the denoiser
+                 num_iterations: int = 5,
+                 lambda_dc_initial: float = 0.05,
+                 learnable_lambda_dc: bool = False,
+                 # shared_weights for denoiser is implicit if only one denoiser_cnn instance is passed and used.
+                 # If separate denoisers per iteration were needed, a list of denoisers would be passed.
+                 num_cg_iterations_dc: int = 5 
+                ):
+        super().__init__()
+        self.num_iterations = num_iterations
+        self.nufft_op = nufft_op # Used by DC layers
+        self.device = nufft_op.device
+
+        # Denoiser (Regularization block)
+        # The same denoiser instance will be used across iterations (shared weights)
+        self.denoiser_cnn = denoiser_cnn 
+
+        # Data Consistency blocks
+        # Each iteration can have its own lambda_dc if learnable_lambda_dc is True,
+        # otherwise, they share the same lambda_dc value.
+        self.dc_layers = nn.ModuleList()
+        for _ in range(num_iterations):
+            if learnable_lambda_dc:
+                # Make lambda_dc a learnable parameter for each DC block
+                # Initialize with lambda_dc_initial, ensure it stays positive (e.g., via softplus or exp)
+                # For simplicity, we'll start with a fixed lambda passed to each,
+                # but a nn.Parameter could be used here.
+                # dc_lambda = nn.Parameter(torch.tensor(lambda_dc_initial, device=self.device, dtype=torch.float32))
+                # For now, let's assume lambda_dc_initial is either a float (fixed for all) or a list/tuple of floats.
+                # The DataConsistencyMoDL class handles scalar tensor for lambda_dc correctly.
+                current_lambda = torch.tensor(lambda_dc_initial, device=self.device, dtype=torch.float32)
+                if learnable_lambda_dc: # Make it a parameter if learnable
+                    current_lambda = nn.Parameter(current_lambda)
+
+            else: # Fixed lambda for all iterations
+                current_lambda = lambda_dc_initial # This will be converted to tensor in DataConsistencyMoDL
+
+            self.dc_layers.append(
+                DataConsistencyMoDL(nufft_op=self.nufft_op, 
+                                    lambda_dc=current_lambda, 
+                                    num_cg_iterations=num_cg_iterations_dc)
+            )
+            
+        # Store lambda_dc for external access if needed (especially if not learnable)
+        # If learnable, they are in self.dc_layers[i].lambda_dc
+        if not learnable_lambda_dc:
+            self.lambda_dc_fixed = torch.tensor(lambda_dc_initial, device=self.device, dtype=torch.float32)
+
+
+    def forward(self, 
+                observed_k_space_y: torch.Tensor, 
+                initial_image_x0: torch.Tensor | None = None
+               ) -> torch.Tensor:
+        """
+        Forward pass of the MoDL network.
+
+        Args:
+            observed_k_space_y: Undersampled k-space data. Shape: (batch_size, num_k_points) or (num_k_points).
+                                 Batching needs to be handled carefully if k-space/image shapes vary per batch item.
+                                 For now, assume batch_size=1 or op is per-example.
+            initial_image_x0: Optional initial image estimate. Shape: (batch_size, *image_shape) or (*image_shape).
+                              If None, it's computed using A^H y.
+        
+        Returns:
+            Reconstructed image. Shape: (batch_size, *image_shape) or (*image_shape).
+        """
+        
+        # Handle potential batch dimension for k-space and image
+        # For simplicity, let's assume inputs are single examples for now, or that
+        # NUFFTOperator and denoiser can handle batch inputs if k_traj is shared.
+        # This example assumes k_traj is fixed in NUFFTOperator, so batching applies to image/k-space data.
+
+        if initial_image_x0 is None:
+            # If k-space is batched (N, num_k_points), op_adj needs to handle it or loop.
+            # Assume op_adj takes (num_k_points,) and returns (*image_shape)
+            if observed_k_space_y.ndim == 2 and observed_k_space_y.shape[0] > 1 : # Batched k-space
+                # Need to process each item in batch, then stack. This complicates things.
+                # For now, let's assume single (num_k_points) k-space input for A^H y.
+                if observed_k_space_y.shape[0] != 1: # Make sure it's not (1, N_k) which is fine
+                    # Or handle batch in op_adj of NUFFTOperator
+                    raise NotImplementedError("Batched k-space for A^H y not directly handled in this example's initial_image_x0 calculation. Assume single k-space input or op_adj handles batches.")
+                current_x_k = self.nufft_op.op_adj(observed_k_space_y.squeeze(0)) # Remove batch dim if (1,Nk)
+                current_x_k = current_x_k.unsqueeze(0) # Add batch dim for network
+            else: # Assumed (num_k_points,)
+                current_x_k = self.nufft_op.op_adj(observed_k_space_y)
+                # Add batch dimension if denoiser expects (N,C,H,W) and image_shape is (H,W)
+                if current_x_k.ndim == len(self.nufft_op.image_shape):
+                     current_x_k = current_x_k.unsqueeze(0) # (1, H, W) or (1, D, H, W)
+        else:
+            current_x_k = initial_image_x0
+            if current_x_k.ndim == len(self.nufft_op.image_shape): # Ensure batch dim
+                 current_x_k = current_x_k.unsqueeze(0)
+
+
+        # Ensure observed_k_space_y also has a batch dim if it's single and x is batched, or vice-versa
+        # This part is tricky depending on how batching is handled by NUFFTOperator vs CNN
+        # For now, assume DC layer handles single y and single x_k, and batching is external if needed.
+        # If current_x_k is (1, ...), and y is (Nk), then DC layer should get y.
+        # If current_x_k is (N, ...), then y should be (N, Nk) and DC layer needs to loop or be batch-aware.
+        # Let's assume for now that forward takes single instance inputs, batching is handled by a trainer.
+        if current_x_k.shape[0] > 1:
+            raise NotImplementedError("Batch processing in MoDLNet forward pass needs careful implementation for DC consistency. Assuming single instance for now.")
+        
+        # If k-space had a batch dim (1, Nk), squeeze it for DC layer if DC layer expects (Nk)
+        if observed_k_space_y.ndim == 2 and observed_k_space_y.shape[0] == 1:
+            observed_k_space_y_for_dc = observed_k_space_y.squeeze(0)
+        else:
+            observed_k_space_y_for_dc = observed_k_space_y
+
+
+        for i in range(self.num_iterations):
+            # Regularization / Denoising step
+            # Denoiser expects (N,C,H,W) or (N,H,W) which it unsqueezes.
+            # If current_x_k is (1, D, H, W) for 3D, denoiser needs to handle 3D.
+            # Current SimpleResNetDenoiser is 2D. This implies MoDLNet needs a 2D/3D aware denoiser or reshaping.
+            # For now, assume denoiser matches dimensionality of x_k.
+            # And if x_k is (1,H,W), denoiser input is fine. If (1,D,H,W), denoiser needs to be 3D.
+            
+            # Let's assume current_x_k is (1, *image_shape)
+            # If denoiser is 2D and image_shape is 3D, this is an issue.
+            # For this example, let's assume denoiser can handle the shape.
+            denoiser_input = current_x_k # This should be (N, C, H, W) or (N, C, D, H, W) for denoiser
+                                        # Our current SimpleResNetDenoiser is 2D (N,C,H,W)
+                                        # If image_shape is 3D, we need a 3D denoiser or process slices.
+                                        # This example will assume image_shape is 2D for now for simplicity with current denoiser.
+            if len(self.nufft_op.image_shape) == 3 and self.denoiser_cnn.initial_conv.in_channels <=2 : # HACK: check if denoiser is 2D
+                 # Process 3D data slice by slice or use a 3D Denoiser
+                 # This is a placeholder for proper 3D handling.
+                 # For now, if 3D input and 2D denoiser, it will likely fail or do something weird.
+                 # We will need a SimpleResNetDenoiser3D or similar.
+                 print("Warning: MoDLNet using a 2D denoiser for 3D data. This needs a 3D denoiser.")
+            
+            denoised_zk = self.denoiser_cnn(denoiser_input) # z_k in paper
+            
+            # Data Consistency step
+            # dc_layer expects current_image_estimate_zk to be (*image_shape)
+            # and observed_k_space_y to be (num_k_points,)
+            current_x_k = self.dc_layers[i](denoised_zk.squeeze(0), observed_k_space_y_for_dc) # x_{k+1} in paper
+            
+            # Re-add batch dim if it was squeezed for DC.
+            if current_x_k.ndim == len(self.nufft_op.image_shape): # If (H,W) or (D,H,W)
+                 current_x_k = current_x_k.unsqueeze(0) # (1, H, W) or (1, D, H, W)
+
+        return current_x_k.squeeze(0) # Return single image result, remove batch dim
+
+if __name__ == '__main__':
+    print("Running MoDLNet basic example...")
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    # Setup for a 2D case
+    img_s = 32
+    ishape = (img_s, img_s)
+    k_pts = 100
+    dims = 2
+    
+    # Dummy NUFFTOperator (using Mock or Real as in DataConsistencyMoDL example)
+    try:
+        k_traj_dummy = torch.rand(k_pts, dims, device=device) - 0.5
+        oversamp_factor_dummy = tuple([2.0]*dims)
+        kb_J_dummy = tuple([4]*dims)
+        kb_alpha_dummy = tuple([2.34 * J for J in kb_J_dummy])
+        Ld_dummy = tuple([2**8]*dims)
+        nufft_op_example = NUFFTOperator(
+            image_shape=ishape, k_trajectory=k_traj_dummy,
+            oversamp_factor=oversamp_factor_dummy, kb_J=kb_J_dummy,
+            kb_alpha=kb_alpha_dummy, Ld=Ld_dummy, device=device
+        )
+        print("Using actual NUFFTOperator for MoDLNet example.")
+    except Exception as e:
+        print(f"Could not init actual NUFFTOperator ({e}), MoDLNet example may not be fully representative.")
+        # Fallback to a mock if needed, but previous DC layer example set one up.
+        # For MoDLNet, it's better if NUFFTOperator is functional.
+        # This example will fail if NUFFTOperator cannot be created.
+        raise
+
+    # Denoiser - assuming 2D data, 1 channel input/output
+    # If input image is complex (e.g. 2 channels for real/imag), adjust in_channels/out_channels
+    denoiser = SimpleResNetDenoiser(in_channels=1, out_channels=1, num_internal_channels=32, num_blocks=2).to(device)
+
+    # MoDLNet
+    modl_network = MoDLNet(nufft_op=nufft_op_example,
+                           denoiser_cnn=denoiser,
+                           num_iterations=3, # K value in paper
+                           lambda_dc_initial=0.05,
+                           num_cg_iterations_dc=3).to(device)
+
+    # Dummy data
+    # Assume initial_image_x0 is (H,W) or (D,H,W) for single batch
+    # And observed_k_space_y is (num_k_points,)
+    initial_image = torch.randn(ishape, dtype=torch.complex64, device=device)
+    k_space_obs = torch.randn(k_pts, dtype=torch.complex64, device=device)
+    
+    # If initial image is None, MoDLNet will compute A^H y
+    # For this test, let's provide one.
+    
+    print(f"Input initial_image shape: {initial_image.shape}")
+    print(f"Input k_space_obs shape: {k_space_obs.shape}")
+
+    # Run forward pass
+    reconstructed_image = modl_network(k_space_obs, initial_image)
+    print(f"Output reconstructed_image shape: {reconstructed_image.shape}")
+    assert reconstructed_image.shape == ishape, "Output shape mismatch!"
+    
+    # Test with initial_image_x0 = None
+    reconstructed_image_no_x0 = modl_network(k_space_obs, None)
+    print(f"Output reconstructed_image_no_x0 shape: {reconstructed_image_no_x0.shape}")
+    assert reconstructed_image_no_x0.shape == ishape, "Output shape mismatch (no x0)!"
+    
+    print("MoDLNet basic example run completed.")

--- a/reconlib/deeplearning/models/resnet_denoiser.py
+++ b/reconlib/deeplearning/models/resnet_denoiser.py
@@ -1,0 +1,96 @@
+import torch
+import torch.nn as nn
+
+class ResNetBlock(nn.Module):
+    """
+    A simple ResNet block with two convolutional layers.
+    Input and output are expected to have the same number of channels.
+    """
+    def __init__(self, num_channels: int, kernel_size: int = 3):
+        super().__init__()
+        padding = kernel_size // 2
+        self.conv1 = nn.Conv2d(num_channels, num_channels, kernel_size, padding=padding, bias=False)
+        self.bn1 = nn.BatchNorm2d(num_channels)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = nn.Conv2d(num_channels, num_channels, kernel_size, padding=padding, bias=False)
+        self.bn2 = nn.BatchNorm2d(num_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out += residual # Add skip connection
+        out = self.relu(out)
+        return out
+
+class SimpleResNetDenoiser(nn.Module):
+    """
+    A simple ResNet-based denoiser for MRI reconstruction.
+    Assumes input is a 2D image (e.g., single slice or processed multi-channel slice).
+    Input shape: (batch_size, in_channels, height, width)
+    Output shape: (batch_size, out_channels, height, width)
+    """
+    def __init__(self, in_channels: int = 1, out_channels: int = 1, num_internal_channels: int = 64, num_blocks: int = 5, kernel_size: int = 3):
+        super().__init__()
+        
+        self.initial_conv = nn.Conv2d(in_channels, num_internal_channels, kernel_size, padding=kernel_size//2, bias=False)
+        self.bn_initial = nn.BatchNorm2d(num_internal_channels)
+        self.relu_initial = nn.ReLU(inplace=True)
+        
+        blocks = []
+        for _ in range(num_blocks):
+            blocks.append(ResNetBlock(num_internal_channels, kernel_size))
+        self.resnet_blocks = nn.Sequential(*blocks)
+        
+        self.final_conv = nn.Conv2d(num_internal_channels, out_channels, kernel_size, padding=kernel_size//2, bias=True) # Bias can be true for final layer
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Expects x to be (N, C, H, W)
+        if x.ndim == 3: # If (N,H,W) or (C,H,W) and C=1, add channel dim
+            if x.shape[0] == 1 and self.initial_conv.in_channels == 1: # (1,H,W)
+                 x = x.unsqueeze(0) # (1,1,H,W) if batch size was 1. Or it's (C,H,W)
+            elif x.ndim == 3 and self.initial_conv.in_channels == x.shape[0]: # (C,H,W)
+                x = x.unsqueeze(0) # (1,C,H,W)
+            elif x.ndim == 3 and self.initial_conv.in_channels == 1: # (N,H,W) assumed
+                 x = x.unsqueeze(1) # (N,1,H,W)
+            else:
+                raise ValueError(f"Input tensor shape {x.shape} not directly compatible with in_channels {self.initial_conv.in_channels}")
+        elif x.ndim == 2: # (H,W)
+            x = x.unsqueeze(0).unsqueeze(0) # (1,1,H,W)
+            if self.initial_conv.in_channels != 1:
+                 raise ValueError(f"Input tensor shape {x.shape} (from H,W) not compatible with in_channels {self.initial_conv.in_channels}")
+
+
+        out = self.initial_conv(x)
+        out = self.bn_initial(out)
+        out = self.relu_initial(out)
+        
+        out = self.resnet_blocks(out)
+        
+        out = self.final_conv(out)
+        
+        return out
+
+if __name__ == '__main__':
+    # Example Usage (simple test)
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    
+    # For a single complex image (real and imag as channels)
+    denoiser_complex = SimpleResNetDenoiser(in_channels=2, out_channels=2, num_internal_channels=32, num_blocks=3).to(device)
+    dummy_complex_image = torch.randn(1, 2, 64, 64, device=device) # Batch=1, Channels=2 (real/imag), H=64, W=64
+    denoised_complex_image = denoiser_complex(dummy_complex_image)
+    print(f"Complex Denoiser: Input shape {dummy_complex_image.shape}, Output shape {denoised_complex_image.shape}")
+
+    # For a single magnitude image
+    denoiser_mag = SimpleResNetDenoiser(in_channels=1, out_channels=1, num_internal_channels=32, num_blocks=3).to(device)
+    dummy_mag_image = torch.randn(1, 1, 64, 64, device=device) # Batch=1, Channels=1, H=64, W=64
+    denoised_mag_image = denoiser_mag(dummy_mag_image)
+    print(f"Magnitude Denoiser: Input shape {dummy_mag_image.shape}, Output shape {denoised_mag_image.shape}")
+
+    # Test with (H,W) input for magnitude
+    dummy_hw_image = torch.randn(64, 64, device=device)
+    denoised_hw_image = denoiser_mag(dummy_hw_image)
+    print(f"Magnitude Denoiser with (H,W) input: Input shape {dummy_hw_image.shape}, Output shape {denoised_hw_image.shape}")

--- a/reconlib/deeplearning/models/unet_denoiser.py
+++ b/reconlib/deeplearning/models/unet_denoiser.py
@@ -1,0 +1,2 @@
+# Placeholder for UNet Denoiser model
+pass

--- a/reconlib/deeplearning/utils/__init__.py
+++ b/reconlib/deeplearning/utils/__init__.py
@@ -1,0 +1,2 @@
+""" Utility functions for Deep Learning data handling in ReconLib. """
+pass

--- a/reconlib/deeplearning/utils/data_utils.py
+++ b/reconlib/deeplearning/utils/data_utils.py
@@ -1,0 +1,188 @@
+import torch
+import numpy as np
+# Adjust path if NUFFTOperator is not directly importable
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))) # Go up three levels for reconlib
+from reconlib.operators import NUFFTOperator # For zero-filled recon
+
+def generate_cartesian_undersampling_mask(
+    image_shape: tuple[int, ...], 
+    acceleration_factor: float, 
+    num_center_lines: int = 16,
+    seed: int | None = None
+) -> torch.Tensor:
+    """
+    Generates a simple Cartesian undersampling mask for 2D or 3D.
+    For 2D (H, W), undersamples along the width dimension (phase-encoding).
+    For 3D (D, H, W), undersamples along the height (phase-encoding dim 1) 
+    and width (phase-encoding dim 2) dimensions. Keeps center lines fully sampled.
+
+    Args:
+        image_shape: Tuple of image dimensions (e.g., (H, W) or (D, H, W)).
+        acceleration_factor: Target acceleration (e.g., 4 for R=4).
+        num_center_lines: Number of lines in the k-space center to keep fully sampled.
+                          For 3D, this applies to both phase-encoding dimensions.
+        seed: Optional random seed for reproducible mask generation.
+
+    Returns:
+        A boolean or float tensor mask of the same shape as k-space (image_shape).
+        True or 1.0 where k-space is sampled, False or 0.0 otherwise.
+    """
+    if seed is not None:
+        torch.manual_seed(seed)
+        np.random.seed(seed) # For numpy random operations if any
+
+    num_dims = len(image_shape)
+    mask = torch.zeros(image_shape, dtype=torch.float32)
+
+    if num_dims == 2: # (H, W), undersample W (phase-encoding)
+        num_lines = image_shape[1]
+        lines_to_keep = int(num_lines / acceleration_factor)
+        
+        center_start = (num_lines - num_center_lines) // 2
+        center_end = center_start + num_center_lines
+        
+        mask[:, center_start:center_end] = 1.0
+        
+        remaining_lines_to_sample = lines_to_keep - num_center_lines
+        if remaining_lines_to_sample < 0: remaining_lines_to_sample = 0
+            
+        outer_region_indices = [i for i in range(num_lines) if not (center_start <= i < center_end)]
+        
+        if remaining_lines_to_sample > 0 and len(outer_region_indices) > 0:
+            if remaining_lines_to_sample >= len(outer_region_indices):
+                 # Keep all outer lines if remaining_lines_to_sample is too high (low acceleration)
+                for i in outer_region_indices:
+                    mask[:, i] = 1.0
+            else:
+                chosen_outer_indices = np.random.choice(outer_region_indices, remaining_lines_to_sample, replace=False)
+                for i in chosen_outer_indices:
+                    mask[:, i] = 1.0
+                    
+    elif num_dims == 3: # (D, H, W), undersample H (PE1) and W (PE2)
+        # This creates a 2D mask and then tiles it across the D dimension (frequency encoding)
+        num_lines_h = image_shape[1] # PE1
+        num_lines_w = image_shape[2] # PE2
+
+        lines_to_keep_h = int(num_lines_h / np.sqrt(acceleration_factor)) # Approx for 2D undersampling
+        lines_to_keep_w = int(num_lines_w / np.sqrt(acceleration_factor))
+
+        center_start_h = (num_lines_h - num_center_lines) // 2
+        center_end_h = center_start_h + num_center_lines
+        center_start_w = (num_lines_w - num_center_lines) // 2
+        center_end_w = center_start_w + num_center_lines
+
+        mask_2d_slice = torch.zeros((num_lines_h, num_lines_w), dtype=torch.float32)
+        mask_2d_slice[center_start_h:center_end_h, :] = 1.0 # Fully sample center H lines first
+        mask_2d_slice[:, center_start_w:center_end_w] = 1.0 # Then fully sample center W lines (union)
+
+        # Count actually sampled lines in center (avoid double counting intersection)
+        center_sampled_count = torch.sum(mask_2d_slice).item()
+        
+        # For outer region, sample randomly based on remaining points needed
+        # This is a simplification; true variable density random sampling is more complex.
+        # Here, we just ensure the total number of points is roughly met.
+        total_points_to_keep = int((num_lines_h * num_lines_w) / acceleration_factor)
+        remaining_points_to_sample = total_points_to_keep - center_sampled_count
+        if remaining_points_to_sample < 0: remaining_points_to_sample = 0
+
+        outer_region_indices_flat = []
+        for r in range(num_lines_h):
+            for c in range(num_lines_w):
+                if mask_2d_slice[r, c] == 0: # If not already in center
+                    outer_region_indices_flat.append(r * num_lines_w + c)
+        
+        if remaining_lines_to_sample > 0 and len(outer_region_indices_flat) > 0:
+            if remaining_points_to_sample >= len(outer_region_indices_flat):
+                for flat_idx in outer_region_indices_flat:
+                    r, c = flat_idx // num_lines_w, flat_idx % num_lines_w
+                    mask_2d_slice[r,c] = 1.0
+            else:
+                chosen_flat_indices = np.random.choice(outer_region_indices_flat, remaining_lines_to_sample, replace=False)
+                for flat_idx in chosen_flat_indices:
+                    r, c = flat_idx // num_lines_w, flat_idx % num_lines_w
+                    mask_2d_slice[r,c] = 1.0
+        
+        mask[:, :, :] = mask_2d_slice.unsqueeze(0) # Tile across the D dimension
+
+    else:
+        raise ValueError(f"Unsupported image dimensionality: {num_dims}. Only 2D or 3D.")
+        
+    return mask
+
+
+def apply_cartesian_mask(k_space_full: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """
+    Applies a Cartesian undersampling mask to fully sampled k-space data.
+    Assumes k_space_full is already FFT-shifted (center at center of matrix).
+    """
+    if k_space_full.shape != mask.shape:
+        raise ValueError(f"k_space_full shape {k_space_full.shape} must match mask shape {mask.shape}")
+    return k_space_full * mask
+
+
+def get_zero_filled_reconstruction(
+    k_space_undersampled_cartesian: torch.Tensor, 
+    image_shape: tuple[int,...], 
+    device: str | torch.device = 'cpu'
+) -> torch.Tensor:
+    """
+    Performs a zero-filled reconstruction from Cartesian undersampled k-space.
+    This is a simple IFFT.
+    k_space_undersampled_cartesian: FFT-shifted k-space data.
+    """
+    if not isinstance(device, torch.device): # Ensure device is a torch.device object
+        device = torch.device(device)
+        
+    if k_space_undersampled_cartesian.device != device:
+        k_space_undersampled_cartesian = k_space_undersampled_cartesian.to(device)
+    
+    # Ensure complex type
+    if not k_space_undersampled_cartesian.is_complex():
+        k_space_undersampled_cartesian = k_space_undersampled_cartesian.to(torch.complex64)
+
+    # IFFT
+    img_zero_filled = torch.fft.ifftshift(torch.fft.ifftn(torch.fft.fftshift(k_space_undersampled_cartesian), s=image_shape))
+    # Scaling to roughly match input data magnitude (optional, but often done)
+    # img_zero_filled = img_zero_filled * float(torch.prod(torch.tensor(image_shape)))
+    return img_zero_filled
+
+
+if __name__ == '__main__':
+    print("Testing data_utils...")
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    # --- 2D Mask Test ---
+    ishape2d = (128, 128)
+    accel2d = 4
+    center2d = 24
+    mask2d = generate_cartesian_undersampling_mask(ishape2d, accel2d, center2d, seed=0)
+    print(f"2D Mask shape: {mask2d.shape}, Sum: {mask2d.sum()}, Expected sum approx: {ishape2d[0]*ishape2d[1]/accel2d}")
+    assert mask2d.shape == ishape2d
+    # Basic check for center lines
+    assert torch.all(mask2d[:, (ishape2d[1]-center2d)//2 : (ishape2d[1]+center2d)//2] == 1.0)
+
+    # --- 3D Mask Test ---
+    ishape3d = (32, 64, 64)
+    accel3d = 4
+    center3d = 12
+    mask3d = generate_cartesian_undersampling_mask(ishape3d, accel3d, center3d, seed=0)
+    print(f"3D Mask shape: {mask3d.shape}, Sum: {mask3d.sum()}, Expected sum approx: {ishape3d[0]*ishape3d[1]*ishape3d[2]/accel3d}")
+    assert mask3d.shape == ishape3d
+    # Basic check for center slice (assuming it's tiled)
+    center_slice_mask_2d = mask3d[0,:,:]
+    assert torch.all(center_slice_mask_2d[(ishape3d[1]-center3d)//2 : (ishape3d[1]+center3d)//2, : ] == 1.0)
+    assert torch.all(center_slice_mask_2d[:, (ishape3d[2]-center3d)//2 : (ishape3d[2]+center3d)//2 ] == 1.0)
+
+
+    # --- Apply Mask and Zero-fill Test (2D) ---
+    phantom_2d_test = torch.randn(ishape2d, dtype=torch.complex64, device=device)
+    kspace_full_2d = torch.fft.fftshift(torch.fft.fftn(torch.fft.ifftshift(phantom_2d_test)))
+    
+    kspace_undersampled_2d = apply_cartesian_mask(kspace_full_2d, mask2d.to(device))
+    img_zf_2d = get_zero_filled_reconstruction(kspace_undersampled_2d, ishape2d, device=device)
+    print(f"Zero-filled 2D image shape: {img_zf_2d.shape}")
+    assert img_zf_2d.shape == ishape2d
+
+    print("data_utils basic tests completed.")

--- a/tests/test_deeplearning.py
+++ b/tests/test_deeplearning.py
@@ -1,0 +1,230 @@
+import torch
+import torch.nn as nn
+import numpy as np
+import math
+import pytest # For test structure, though not for running in this env
+
+# Adjust path to import from reconlib
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from reconlib.operators import NUFFTOperator # For type hinting and potential use
+from reconlib.deeplearning.models.resnet_denoiser import SimpleResNetDenoiser
+from reconlib.deeplearning.layers.data_consistency import DataConsistencyMoDL
+from reconlib.deeplearning.models.modl_network import MoDLNet
+
+# Mock NUFFTOperator for testing DL components without full NUFFT setup
+class MockNUFFTOperator:
+    def __init__(self, image_shape, k_traj_len, device_):
+        self.image_shape = image_shape
+        self.dim = len(image_shape)
+        # k_trajectory must be (num_points, dim)
+        self.k_trajectory = torch.zeros(k_traj_len, self.dim, device=device_) 
+        self.device = device_
+
+    def op(self, x: torch.Tensor) -> torch.Tensor: # A
+        # Forward: image -> k-space
+        # Dummy op: returns tensor of shape (k_traj_len,)
+        # Ensure it's on the same device and complex type as input if x is complex
+        return torch.ones(self.k_trajectory.shape[0], dtype=x.dtype if x.is_complex() else torch.complex64, device=x.device) * torch.mean(torch.abs(x))
+
+    def op_adj(self, y: torch.Tensor) -> torch.Tensor: # A_H
+        # Adjoint: k-space -> image
+        # Dummy op_adj: returns tensor of image_shape
+        return torch.ones(self.image_shape, dtype=y.dtype if y.is_complex() else torch.complex64, device=y.device) * torch.mean(torch.abs(y))
+
+@pytest.fixture
+def device():
+    return torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+@pytest.fixture
+def setup_2d_data(device):
+    img_s = 32 # Smaller for tests
+    ishape = (img_s, img_s)
+    k_pts = 100
+    nufft_op = MockNUFFTOperator(image_shape=ishape, k_traj_len=k_pts, device_=device)
+    return {
+        'image_shape': ishape,
+        'k_space_points': k_pts,
+        'nufft_op': nufft_op,
+        'denoiser_channels': 1,
+        'device': device
+    }
+
+@pytest.fixture
+def setup_3d_data(device):
+    img_s = 16 # Smaller for tests
+    ishape = (img_s, img_s, img_s)
+    k_pts = 200
+    nufft_op = MockNUFFTOperator(image_shape=ishape, k_traj_len=k_pts, device_=device)
+    return {
+        'image_shape': ishape,
+        'k_space_points': k_pts,
+        'nufft_op': nufft_op,
+        'denoiser_channels': 1, # Assuming magnitude processing for simplicity with current ResNet
+        'device': device
+    }
+
+# --- Test SimpleResNetDenoiser ---
+def test_resnet_denoiser_instantiation(setup_2d_data):
+    print("Test: SimpleResNetDenoiser Instantiation")
+    denoiser = SimpleResNetDenoiser(
+        in_channels=setup_2d_data['denoiser_channels'],
+        out_channels=setup_2d_data['denoiser_channels'],
+        num_internal_channels=16,
+        num_blocks=1
+    ).to(setup_2d_data['device'])
+    assert isinstance(denoiser, nn.Module)
+    print("  Passed.")
+
+def test_resnet_denoiser_forward_2d(setup_2d_data):
+    print("Test: SimpleResNetDenoiser 2D Forward Pass")
+    denoiser = SimpleResNetDenoiser(
+        in_channels=setup_2d_data['denoiser_channels'],
+        out_channels=setup_2d_data['denoiser_channels'],
+        num_internal_channels=16,
+        num_blocks=1
+    ).to(setup_2d_data['device'])
+    
+    bs = 2
+    dummy_image = torch.randn(bs, setup_2d_data['denoiser_channels'], *setup_2d_data['image_shape'], device=setup_2d_data['device'])
+    output = denoiser(dummy_image)
+    assert output.shape == dummy_image.shape
+    assert not torch.isnan(output).any() and not torch.isinf(output).any()
+    assert torch.norm(output - dummy_image) > 1e-3 # Ensure it's not an identity function
+    print(f"  Input shape: {dummy_image.shape}, Output shape: {output.shape}. Passed.")
+
+# --- Test DataConsistencyMoDL ---
+def test_dc_modl_instantiation(setup_2d_data):
+    print("Test: DataConsistencyMoDL Instantiation")
+    dc_layer = DataConsistencyMoDL(
+        nufft_op=setup_2d_data['nufft_op'],
+        lambda_dc=0.05,
+        num_cg_iterations=2
+    ).to(setup_2d_data['device'])
+    assert isinstance(dc_layer, nn.Module)
+    print("  Passed.")
+
+def test_dc_modl_forward_2d(setup_2d_data):
+    print("Test: DataConsistencyMoDL 2D Forward Pass & CG Behavior")
+    nufft_op = setup_2d_data['nufft_op']
+    dc_layer = DataConsistencyMoDL(
+        nufft_op=nufft_op,
+        lambda_dc=0.05,
+        num_cg_iterations=3
+    ).to(setup_2d_data['device'])
+    
+    # zk: current image estimate from denoiser
+    zk = torch.randn(setup_2d_data['image_shape'], dtype=torch.complex64, device=setup_2d_data['device'])
+    # y: observed k-space data
+    y_obs = torch.randn(setup_2d_data['k_space_points'], dtype=torch.complex64, device=setup_2d_data['device'])
+    
+    output_image = dc_layer(zk, y_obs)
+    assert output_image.shape == zk.shape
+    assert not torch.isnan(output_image).any() and not torch.isinf(output_image).any()
+    print(f"  Input zk shape: {zk.shape}, y_obs shape: {y_obs.shape}, Output shape: {output_image.shape}. Passed basic checks.")
+
+    # Simple CG behavior check: if rhs (b) is zero, output should be close to zero
+    # The (A^H A + lambda I)x = b system with b=0 should yield x=0 because (A^H A + lambda I) is positive definite for lambda > 0.
+    # Let's test if the residual is reduced by CG for a non-zero RHS
+    rhs_b_test = nufft_op.op_adj(y_obs) + dc_layer.lambda_dc * zk # A non-zero RHS
+    x_initial_cg = torch.zeros_like(rhs_b_test) # Standard CG starts with x=0
+    
+    # Calculate initial residual for (A^H A + lambda I)x = rhs_b_test, with x = x_initial_cg
+    initial_residual = rhs_b_test - dc_layer.operator_AHA_plus_lambda_I(x_initial_cg)
+    initial_residual_norm = torch.norm(initial_residual)
+    
+    x_after_cg = dc_layer._cg_solve(rhs_b_test, max_iter=dc_layer.num_cg_iterations)
+    
+    # Calculate final residual for (A^H A + lambda I)x = rhs_b_test, with x = x_after_cg
+    final_residual = rhs_b_test - dc_layer.operator_AHA_plus_lambda_I(x_after_cg)
+    final_residual_norm = torch.norm(final_residual)
+    
+    # Residual norm should decrease or stay very small if already converged
+    assert final_residual_norm < initial_residual_norm or torch.isclose(final_residual_norm, initial_residual_norm, atol=1e-5) 
+    print(f"  CG residual norm check: Initial: {initial_residual_norm:.2e}, Final: {final_residual_norm:.2e}. Passed.")
+
+
+# --- Test MoDLNet ---
+def test_modl_net_instantiation(setup_2d_data):
+    print("Test: MoDLNet Instantiation")
+    denoiser = SimpleResNetDenoiser(
+        in_channels=setup_2d_data['denoiser_channels'], 
+        out_channels=setup_2d_data['denoiser_channels'],
+        num_blocks=1).to(setup_2d_data['device'])
+    modl_net = MoDLNet(
+        nufft_op=setup_2d_data['nufft_op'],
+        denoiser_cnn=denoiser,
+        num_iterations=2,
+        lambda_dc_initial=0.05,
+        num_cg_iterations_dc=2
+    ).to(setup_2d_data['device'])
+    assert isinstance(modl_net, nn.Module)
+    print("  Passed.")
+
+def test_modl_net_forward_2d(setup_2d_data):
+    print("Test: MoDLNet 2D Forward Pass")
+    denoiser = SimpleResNetDenoiser(
+        in_channels=setup_2d_data['denoiser_channels'], 
+        out_channels=setup_2d_data['denoiser_channels'],
+        num_blocks=1).to(setup_2d_data['device'])
+    modl_net = MoDLNet(
+        nufft_op=setup_2d_data['nufft_op'],
+        denoiser_cnn=denoiser,
+        num_iterations=2,
+        lambda_dc_initial=0.05,
+        num_cg_iterations_dc=2
+    ).to(setup_2d_data['device'])
+    
+    y_obs = torch.randn(setup_2d_data['k_space_points'], dtype=torch.complex64, device=setup_2d_data['device'])
+    x0 = torch.randn(setup_2d_data['image_shape'], dtype=torch.complex64, device=setup_2d_data['device'])
+    
+    reconstructed_image = modl_net(y_obs, x0)
+    assert reconstructed_image.shape == setup_2d_data['image_shape']
+    assert not torch.isnan(reconstructed_image).any() and not torch.isinf(reconstructed_image).any()
+    # Check if output is different from input x0 (it should be after denoiser and DC)
+    assert torch.norm(reconstructed_image - x0) > 1e-3 if torch.norm(x0) > 1e-9 else True
+    print(f"  Input y_obs shape: {y_obs.shape}, x0 shape: {x0.shape}, Output shape: {reconstructed_image.shape}. Passed.")
+
+    # Test with x0 = None
+    reconstructed_image_no_x0 = modl_net(y_obs, None)
+    assert reconstructed_image_no_x0.shape == setup_2d_data['image_shape']
+    assert not torch.isnan(reconstructed_image_no_x0).any() and not torch.isinf(reconstructed_image_no_x0).any()
+    print(f"  Forward pass with x0=None also successful. Output shape: {reconstructed_image_no_x0.shape}. Passed.")
+
+
+# It's harder to make a simple 3D denoiser and test it without Conv3d, etc.
+# For now, focus tests on 2D setup where SimpleResNetDenoiser is appropriate.
+# A 3D test would be structured similarly if a 3D denoiser was available.
+
+if __name__ == '__main__':
+    # This allows running the tests directly, e.g. python tests/test_deeplearning.py
+    # Pytest would discover and run functions starting with "test_"
+    print("Starting DL component tests...")
+    current_device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    print(f"Using device: {current_device}")
+
+    # Manually create data for non-pytest environment
+    data_2d_fixture = {
+        'image_shape': (32,32),
+        'k_space_points': 100,
+        'nufft_op': MockNUFFTOperator(image_shape=(32,32), k_traj_len=100, device_=current_device),
+        'denoiser_channels': 1,
+        'device': current_device
+    }
+    
+    test_resnet_denoiser_instantiation(data_2d_fixture)
+    test_resnet_denoiser_forward_2d(data_2d_fixture)
+    
+    test_dc_modl_instantiation(data_2d_fixture)
+    test_dc_modl_forward_2d(data_2d_fixture) # Includes CG behavior check
+    
+    test_modl_net_instantiation(data_2d_fixture)
+    test_modl_net_forward_2d(data_2d_fixture)
+    
+    # Add calls to 3D tests here if/when a 3D denoiser is implemented
+    # data_3d_fixture = setup_3d_data(current_device) # if setup_3d_data was not a fixture
+    # ... (call 3D versions of tests) ...
+    
+    print("\nDL component tests completed.")


### PR DESCRIPTION
This commit introduces an initial framework for deep learning based MRI reconstruction into ReconLib, focusing on a Model-based Deep Learning (MoDL) unrolled network architecture.

Key Additions:
- New `reconlib.deeplearning` module:
  - `models/resnet_denoiser.py`: A SimpleResNetDenoiser CNN.
  - `models/modl_network.py`: The main MoDLNet unrolled architecture, which alternates between a denoiser and data consistency.
  - `layers/data_consistency.py`: A DataConsistencyMoDL layer that uses the existing NUFFTOperator and a Conjugate Gradient solver to enforce data fidelity.
  - `utils/data_utils.py`: Basic utilities for Cartesian mask generation and zero-filled reconstruction.
  - `datasets.py`: A `MoDLDataset` for on-the-fly generation of training/evaluation data using phantoms and NUFFT operations.

- New example scripts:
  - `examples/unrolled_dl_train.py`: Script to train the MoDLNet.
  - `examples/unrolled_dl_evaluate.py`: Script to evaluate a trained MoDLNet.
  - `examples/modl_recon_demo.ipynb`: Jupyter notebook demonstrating the setup and a mock inference run of a 2D MoDL model.

- Initial Unit Tests:
  - `tests/test_deeplearning.py`: Basic tests for instantiation and forward passes of the new DL components.

- Documentation:
  - README.md updated to mention the new experimental DL capabilities.
  - Docstrings added to new modules.

This framework leverages the existing self-contained NUFFTOperator for the data consistency steps within the MoDL network. Further work would involve more rigorous testing, advanced data handling, support for 3D denoisers, and training on realistic datasets.