### PR TITLE
feat: Implement coil combination module with phase estimation

### DIFF
--- a/reconlib/__init__.py
+++ b/reconlib/__init__.py
@@ -30,6 +30,14 @@ from .reconstructors import ProximalGradientReconstructor, POCSENSEreconstructor
 from .utils import calculate_density_compensation
 from .csm import estimate_csm_from_central_kspace
 
+from .coil_combination import (
+    coil_combination_with_phase,
+    estimate_phase_maps,
+    estimate_sensitivity_maps,
+    reconstruct_coil_images,
+    compute_density_compensation
+)
+
 # Exports from wavelets_scratch.py
 from .wavelets_scratch import WaveletTransform
 from .wavelets_scratch import WaveletRegularizationTerm
@@ -74,6 +82,11 @@ __all__ = [
     'generate_nlinv_data_stubs',
     'plotting',
     'preprocess_multi_coil_multi_echo_data',
+    "coil_combination_with_phase",
+    "estimate_phase_maps",
+    "estimate_sensitivity_maps",
+    "reconstruct_coil_images",
+    "compute_density_compensation",
 ]
 
 # Note: The original __init__.py had imports like:

--- a/reconlib/coil_combination.py
+++ b/reconlib/coil_combination.py
@@ -1,0 +1,506 @@
+import numpy as np
+import scipy.ndimage
+import scipy.fft
+
+EPSILON = 1e-9
+
+# Placeholder functions for operations not directly implemented yet
+def regrid_kspace(kspace_data, trajectory, grid_size, density_weights=None):
+    """Placeholder for k-space regridding operation."""
+    raise NotImplementedError("regrid_kspace not yet implemented.")
+
+def filter_low_frequencies(kspace_data, trajectory):
+    """Placeholder for filtering low k-space frequencies."""
+    raise NotImplementedError("filter_low_frequencies not yet implemented.")
+
+def extract_calibration_region(kspace_data, trajectory):
+    """Placeholder for extracting calibration region for ESPIRiT."""
+    raise NotImplementedError("extract_calibration_region not yet implemented.")
+
+def compute_espirit_kernel(calibration_data):
+    """Placeholder for computing ESPIRiT kernel."""
+    raise NotImplementedError("compute_espirit_kernel not yet implemented.")
+
+def apply_espirit_kernel(kernel, grid_size):
+    """Placeholder for applying ESPIRiT kernel."""
+    raise NotImplementedError("apply_espirit_kernel not yet implemented.")
+
+def compute_voronoi_tessellation(coords):
+    """Placeholder for Voronoi tessellation."""
+    raise NotImplementedError("compute_voronoi_tessellation not yet implemented. Consider using scipy.spatial.Voronoi if available and appropriate.")
+
+def compute_polygon_area(vertices):
+    """Placeholder for computing polygon area."""
+    raise NotImplementedError("compute_polygon_area not yet implemented.")
+
+
+def coil_combination_with_phase(coil_images, method="sos", sensitivity_maps=None, phase_maps=None):
+    """
+    Combine images from multiple coils with phase correction.
+
+    Args:
+        coil_images (np.ndarray): Array of reconstructed coil images, shape (num_coils, Nx, Ny[, Nz]).
+        method (str): "sos" (sum-of-squares), "roemer" (optimal), or "sos_sensitivity" (SoS with sensitivity).
+        sensitivity_maps (np.ndarray, optional): Coil sensitivity maps, shape (num_coils, Nx, Ny[, Nz]).
+        phase_maps (np.ndarray, optional): Coil phase maps, shape (num_coils, Nx, Ny[, Nz]).
+
+    Returns:
+        np.ndarray: Combined image, shape (Nx, Ny[, Nz]).
+    """
+    if not isinstance(coil_images, np.ndarray):
+        raise TypeError("coil_images must be a NumPy array.")
+    if coil_images.ndim < 3:
+        raise ValueError("coil_images must have at least 3 dimensions (num_coils, Nx, Ny).")
+
+    num_coils = coil_images.shape[0]
+    image_shape = coil_images.shape[1:]
+
+    # Step 1: Estimate phase maps if not provided
+    if phase_maps is None:
+        phase_maps = estimate_phase_maps(coil_images, method="lowres")
+
+    if phase_maps.shape != coil_images.shape:
+        raise ValueError(f"phase_maps shape {phase_maps.shape} must match coil_images shape {coil_images.shape}.")
+
+    # Step 2: Apply phase correction to coil images
+    corrected_images = np.empty_like(coil_images, dtype=np.complex128)
+    for coil in range(num_coils):
+        corrected_images[coil] = coil_images[coil] * np.exp(-1j * phase_maps[coil])
+
+    # Step 3: Perform coil combination
+    if method == "sos":
+        combined_image = np.sum(np.abs(corrected_images) ** 2, axis=0)
+        combined_image = np.sqrt(combined_image)
+    elif method == "roemer":
+        if sensitivity_maps is None:
+            raise ValueError("Sensitivity maps required for Roemer combination.")
+        if sensitivity_maps.shape != coil_images.shape:
+            raise ValueError(f"sensitivity_maps shape {sensitivity_maps.shape} must match coil_images shape {coil_images.shape}.")
+        
+        # Reshape for vectorized operations: (num_coils, N_pixels)
+        # N_pixels = np.prod(image_shape)
+        # corrected_images_flat = corrected_images.reshape(num_coils, N_pixels)
+        # sensitivity_maps_flat = sensitivity_maps.reshape(num_coils, N_pixels)
+        
+        # combined_image_flat = np.zeros(N_pixels, dtype=np.complex128)
+        
+        # norm_sens_sq = np.sum(np.abs(sensitivity_maps_flat)**2, axis=0) # Norm squared for each pixel
+        # weights_numerator = np.conj(sensitivity_maps_flat)
+        
+        # # Avoid division by zero where norm_sens_sq is close to zero
+        # valid_pixels = norm_sens_sq > EPSILON
+        
+        # weights = np.zeros_like(sensitivity_maps_flat, dtype=np.complex128)
+        # weights[:, valid_pixels] = weights_numerator[:, valid_pixels] / norm_sens_sq[valid_pixels]
+        
+        # combined_image_flat[valid_pixels] = np.sum(corrected_images_flat[:, valid_pixels] * weights[:, valid_pixels], axis=0)
+        # combined_image = np.abs(combined_image_flat.reshape(image_shape))
+
+        # Using broadcasting and avoiding explicit pixel loop
+        # Denominator: sum(|S_i|^2) over coils for each pixel
+        sensitivity_norm_sq = np.sum(np.abs(sensitivity_maps)**2, axis=0) # Shape: (Nx, Ny[, Nz])
+        
+        # Weights: S_i* / sum(|S_j|^2)
+        # Add EPSILON to avoid division by zero
+        weights_numerator = np.conj(sensitivity_maps) # Shape: (num_coils, Nx, Ny[, Nz])
+        
+        # Ensure sensitivity_norm_sq has same dimensions as weights_numerator for broadcasting
+        # This is usually fine if sensitivity_norm_sq is (Nx, Ny) and weights_numerator is (num_coils, Nx, Ny)
+        # but if sensitivity_norm_sq is (Nx,Ny,Nz), it matches weights_numerator's trailing dims.
+        
+        weights = weights_numerator / (sensitivity_norm_sq[np.newaxis, ...] + EPSILON) # Add newaxis for broadcasting over coils
+        
+        # Combined image: sum(C_i * W_i) over coils
+        combined_image = np.sum(corrected_images * weights, axis=0)
+        combined_image = np.abs(combined_image)
+
+    elif method == "sos_sensitivity":
+        if sensitivity_maps is None:
+            raise ValueError("Sensitivity maps required for SoS with sensitivity.")
+        if sensitivity_maps.shape != coil_images.shape:
+            raise ValueError(f"sensitivity_maps shape {sensitivity_maps.shape} must match coil_images shape {coil_images.shape}.")
+        
+        weighted_images_sq = (np.abs(corrected_images) * np.abs(sensitivity_maps)) ** 2
+        combined_image = np.sqrt(np.sum(weighted_images_sq, axis=0))
+    else:
+        raise ValueError(f"Unknown coil combination method: {method}")
+
+    # Step 4: Normalize output
+    max_val = np.max(combined_image)
+    if max_val > 0:
+        combined_image = combined_image / max_val
+
+    return combined_image
+
+
+def estimate_phase_maps(coil_images, method="lowres", reference_coil=0):
+    """
+    Estimate phase maps for each coil to align phases.
+
+    Args:
+        coil_images (np.ndarray): Array of reconstructed coil images, shape (num_coils, Nx, Ny[, Nz]).
+        method (str): "lowres" (low-resolution phase estimation) or "reference" (relative to a reference coil).
+        reference_coil (int): Index of reference coil for "reference" method.
+
+    Returns:
+        np.ndarray: Phase maps, shape (num_coils, Nx, Ny[, Nz]).
+    """
+    if not isinstance(coil_images, np.ndarray):
+        raise TypeError("coil_images must be a NumPy array.")
+    if coil_images.ndim < 3:
+        raise ValueError("coil_images must have at least 3 dimensions (num_coils, Nx, Ny).")
+
+    num_coils = coil_images.shape[0]
+    image_shape = coil_images.shape[1:]
+    phase_maps = np.empty_like(coil_images, dtype=float) # Phase is real
+
+    if method == "lowres":
+        # Determine sigma for Gaussian filter based on image size (heuristic)
+        # For a cutoff of 0.1, this means features smaller than 10% of image size are smoothed.
+        # Sigma is related to cutoff frequency. A common heuristic: sigma = 1 / (2 * pi * cutoff_norm)
+        # cutoff_norm = cutoff_freq / sampling_freq. Here, sampling_freq is related to image dimension.
+        # Let's use a fraction of the image dimension for sigma.
+        # For example, sigma = 0.05 * min(image_shape)
+        sigmas = [0.05 * s for s in image_shape] # Separate sigma for each dimension
+        if len(sigmas) == 2: # 2D case
+             sigmas_for_filter = [0] + sigmas # Add 0 for coil dimension
+        else: # 3D case
+             sigmas_for_filter = [0] + sigmas # Add 0 for coil dimension
+
+        for coil in range(num_coils):
+            # Apply low-pass filter to complex image, then extract phase
+            # It's generally better to filter the complex image then take the angle,
+            # rather than filtering the phase directly, which can have wrapping issues.
+            # However, pseudocode suggests filtering the image and then taking angle.
+            # To match pseudocode "LOW_PASS_FILTER(coil_images[coil], cutoff=0.1)"
+            # we filter the magnitude and phase separately if we interpret it strictly,
+            # or more commonly, filter the complex image.
+            # Let's filter the complex image by filtering real and imaginary parts.
+            lowres_real = scipy.ndimage.gaussian_filter(coil_images[coil].real, sigma=sigmas, mode='wrap')
+            lowres_imag = scipy.ndimage.gaussian_filter(coil_images[coil].imag, sigma=sigmas, mode='wrap')
+            lowres_image = lowres_real + 1j * lowres_imag
+            phase_maps[coil] = np.angle(lowres_image)
+    elif method == "reference":
+        if not (0 <= reference_coil < num_coils):
+            raise ValueError(f"reference_coil index {reference_coil} is out of bounds for {num_coils} coils.")
+        ref_phase = np.angle(coil_images[reference_coil])
+        for coil in range(num_coils):
+            phase_maps[coil] = np.angle(coil_images[coil]) - ref_phase
+            # Unwrap phase differences? Pseudocode doesn't specify, but could be useful.
+            # phase_maps[coil] = np.unwrap(phase_maps[coil]) # Might be too aggressive
+    else:
+        raise ValueError(f"Unknown phase estimation method: {method}")
+
+    # Smooth phase maps to reduce noise
+    # Kernel size 5 suggests a sigma of around 1 to 1.5 for Gaussian filter
+    # For multiple dimensions, kernel_size=5 might mean (5,5) or (5,5,5)
+    # Let's use a fixed sigma for smoothing.
+    smoothing_sigma = [1.5] * len(image_shape) # Sigma for each spatial dimension
+    for coil in range(num_coils):
+        phase_maps[coil] = scipy.ndimage.gaussian_filter(phase_maps[coil], sigma=smoothing_sigma, mode='wrap')
+        # Note: 'wrap' mode for phase data is important.
+
+    return phase_maps
+
+
+def estimate_sensitivity_maps(kspace_data, trajectory, grid_size, method="lowres"):
+    """
+    Estimate coil sensitivity maps from k-space data.
+
+    Args:
+        kspace_data (np.ndarray): Complex k-space data, shape (num_coils, num_arms, num_samples) or (num_coils, N_kpoints).
+        trajectory (np.ndarray): K-space trajectory, shape (num_arms, num_samples, 2 or 3) or (N_kpoints, 2 or 3).
+        grid_size (list or tuple): Size of output image grid (e.g., [Nx, Ny]).
+        method (str): "lowres" (low-resolution image) or "espirit".
+
+    Returns:
+        np.ndarray: Complex array, shape (num_coils, Nx, Ny) or (num_coils, Nx, Ny, Nz).
+    """
+    if not isinstance(kspace_data, np.ndarray) or not np.iscomplexobj(kspace_data):
+        raise TypeError("kspace_data must be a complex NumPy array.")
+    if kspace_data.ndim < 2: # (num_coils, N_kpoints)
+        raise ValueError("kspace_data must have at least 2 dimensions.")
+    
+    num_coils = kspace_data.shape[0]
+    
+    # Ensure grid_size is a tuple for consistency
+    if not isinstance(grid_size, tuple):
+        grid_size = tuple(grid_size)
+        
+    sensitivity_maps_shape = (num_coils,) + grid_size
+    sensitivity_maps = np.empty(sensitivity_maps_shape, dtype=np.complex128)
+
+    if method == "lowres":
+        # This implementation assumes regrid_kspace and filter_low_frequencies are available.
+        # The division by 2 for grid_size in regrid_kspace call is a bit arbitrary,
+        # depends on how "low resolution" is defined. Let's assume a fixed low-res grid.
+        # For example, grid_size // 4 or a fixed size like (32,32).
+        # Pseudocode has grid_size / 2 for regrid, then upsample to grid_size.
+        
+        low_res_grid_size = tuple(s // 2 for s in grid_size)
+        if any(s == 0 for s in low_res_grid_size): # Ensure grid dims are not zero
+            low_res_grid_size = tuple(max(1,s) for s in low_res_grid_size)
+
+        for coil in range(num_coils):
+            # 1. Filter low frequencies (conceptual step, depends on definition)
+            # Assuming kspace_data[coil] might be (num_arms, num_samples)
+            # and trajectory might be (num_arms, num_samples, dims)
+            # For simplicity, we'll assume filter_low_frequencies returns k-space data
+            # that can be directly used by regrid_kspace.
+            # This might involve selecting k-space points near the center.
+            lowres_kspace_filtered = filter_low_frequencies(kspace_data[coil], trajectory) # Placeholder
+            
+            # 2. Regrid to a low-resolution Cartesian grid
+            # The trajectory passed to regrid_kspace here should correspond to lowres_kspace_filtered
+            lowres_cartesian_kspace = regrid_kspace(lowres_kspace_filtered, trajectory, low_res_grid_size) # Placeholder
+
+            # 3. Inverse FFT
+            if len(grid_size) == 2:
+                lowres_image = scipy.fft.ifft2(scipy.fft.ifftshift(lowres_cartesian_kspace))
+            elif len(grid_size) == 3:
+                lowres_image = scipy.fft.ifftn(scipy.fft.ifftshift(lowres_cartesian_kspace))
+            else:
+                raise ValueError(f"Unsupported grid dimension: {len(grid_size)}")
+            
+            # 4. Upsample to original grid_size
+            zoom_factors = [gs_orig / gs_low for gs_orig, gs_low in zip(grid_size, lowres_image.shape)]
+            # scipy.ndimage.zoom expects zoom factors for each dimension.
+            # If lowres_image is complex, zoom real and imaginary parts separately.
+            s_map_real = scipy.ndimage.zoom(lowres_image.real, zoom_factors, order=1) # Bilinear interpolation
+            s_map_imag = scipy.ndimage.zoom(lowres_image.imag, zoom_factors, order=1)
+            sensitivity_maps[coil] = s_map_real + 1j * s_map_imag
+        
+        # Normalize by Sum-of-Squares of all coil sensitivities
+        sos = np.sqrt(np.sum(np.abs(sensitivity_maps) ** 2, axis=0))
+        
+        # Add EPSILON for stability, expand sos dims to match sensitivity_maps for broadcasting
+        sensitivity_maps = sensitivity_maps / (sos[np.newaxis, ...] + EPSILON)
+
+    elif method == "espirit":
+        # calibration_data = extract_calibration_region(kspace_data, trajectory) # Placeholder
+        # for coil in range(num_coils):
+        #     kernel = compute_espirit_kernel(calibration_data[coil]) # Placeholder
+        #     sensitivity_maps[coil] = apply_espirit_kernel(kernel, grid_size) # Placeholder
+        # sos = np.sqrt(np.sum(np.abs(sensitivity_maps) ** 2, axis=0))
+        # sensitivity_maps = sensitivity_maps / (sos[np.newaxis, ...] + EPSILON)
+        raise NotImplementedError("ESPIRiT method not yet implemented in this translation.")
+    else:
+        raise ValueError(f"Unknown sensitivity estimation method: {method}")
+
+    return sensitivity_maps
+
+
+def reconstruct_coil_images(kspace_data, trajectory, grid_size, density_weights=None):
+    """
+    Reconstruct individual coil images from non-Cartesian k-space data.
+
+    Args:
+        kspace_data (np.ndarray): Complex k-space data, shape (num_coils, num_arms, num_samples) or (num_coils, N_kpoints).
+        trajectory (np.ndarray): K-space trajectory, shape (num_arms, num_samples, 2 or 3) or (N_kpoints, 2 or 3).
+        grid_size (list or tuple): Size of output image grid (e.g., [Nx, Ny]).
+        density_weights (np.ndarray, optional): Density compensation weights. Shape should match trajectory samples.
+
+    Returns:
+        np.ndarray: Complex array of coil images, shape (num_coils, Nx, Ny) or (num_coils, Nx, Ny, Nz).
+    """
+    if not isinstance(kspace_data, np.ndarray) or not np.iscomplexobj(kspace_data):
+        raise TypeError("kspace_data must be a complex NumPy array.")
+    if kspace_data.ndim < 2:
+        raise ValueError("kspace_data must have at least 2 dimensions.")
+
+    num_coils = kspace_data.shape[0]
+    if not isinstance(grid_size, tuple):
+        grid_size = tuple(grid_size)
+        
+    coil_images_shape = (num_coils,) + grid_size
+    coil_images = np.empty(coil_images_shape, dtype=np.complex128)
+
+    if density_weights is None:
+        # Assuming trajectory might be (num_arms, num_samples, dims) or (N_kpoints, dims)
+        # compute_density_compensation needs to handle these shapes.
+        density_weights = compute_density_compensation(trajectory, method="pipe") # Default to pipe if Voronoi is complex
+
+    # Validate shape of density_weights against kspace_data[coil] and trajectory
+    # If kspace_data is (num_coils, num_arms, num_samples), density_weights could be (num_arms, num_samples)
+    # If kspace_data is (num_coils, N_kpoints), density_weights could be (N_kpoints,)
+    # This needs to be handled inside regrid_kspace or by reshaping density_weights.
+    # For now, assume density_weights has a compatible shape for regrid_kspace.
+
+    for coil in range(num_coils):
+        # The regrid_kspace function is assumed to handle non-Cartesian data and apply density compensation.
+        # kspace_data[coil] would be (num_arms, num_samples) or (N_kpoints)
+        # trajectory would be (num_arms, num_samples, dims) or (N_kpoints, dims)
+        gridded_k_space = regrid_kspace(kspace_data[coil], trajectory, grid_size, density_weights) # Placeholder
+        
+        # Perform Inverse FFT (centered)
+        # Use ifftshift before IFFT to handle k-space center, and fftshift after for image center (if needed by convention)
+        # Standard is ifftshift -> ifft -> fftshift
+        shifted_gridded_k_space = scipy.fft.ifftshift(gridded_k_space)
+        if len(grid_size) == 2:
+            img = scipy.fft.ifft2(shifted_gridded_k_space)
+        elif len(grid_size) == 3:
+            img = scipy.fft.ifftn(shifted_gridded_k_space)
+        else:
+            raise ValueError(f"Unsupported grid dimension: {len(grid_size)}")
+        coil_images[coil] = scipy.fft.fftshift(img) # Center the image
+
+    return coil_images
+
+
+def compute_density_compensation(trajectory, method="voronoi"):
+    """
+    Compute density compensation weights for non-Cartesian trajectory.
+
+    Args:
+        trajectory (np.ndarray): K-space trajectory.
+                       Expected shapes: (num_total_samples, dims) for real coordinates,
+                       or (num_total_samples,) for complex coordinates (dim inferred as 2).
+                       `dims` is typically 2 or 3.
+        method (str): "voronoi" or "pipe".
+
+    Returns:
+        np.ndarray: Density compensation weights. Shape will be (num_total_samples,).
+    """
+    if not isinstance(trajectory, np.ndarray):
+        raise TypeError("trajectory must be a NumPy array.")
+
+    # Determine shape of trajectory and ensure it's 2D (N_points, N_dims) or 1D (N_points, complex)
+    if trajectory.ndim == 3: # (num_arms, num_samples, dims)
+        num_arms, num_samples, dims = trajectory.shape
+        trajectory_flat = trajectory.reshape(-1, dims) # (N_total_samples, dims)
+        original_shape = (num_arms, num_samples)
+    elif trajectory.ndim == 2: # (N_total_samples, dims) or (num_arms, num_samples) if complex
+        if np.iscomplexobj(trajectory): # (num_arms, num_samples) complex, treat as (N_total_samples,) complex
+            trajectory_flat = trajectory.flatten() # (N_total_samples,) complex
+            original_shape = trajectory.shape
+        else: # (N_total_samples, dims) real
+            trajectory_flat = trajectory
+            original_shape = (trajectory.shape[0],) # Output will be 1D
+    elif trajectory.ndim == 1: # (N_total_samples,) complex or real (1D trajectory?)
+        trajectory_flat = trajectory # Assume (N_total_samples,)
+        original_shape = trajectory.shape
+        if not np.iscomplexobj(trajectory_flat) and method != "pipe": # Pipe method can work with 1D real (radius)
+             # For Voronoi, 1D real trajectory is ambiguous without more context.
+             # Assuming it might be radial distance for pipe, or needs to be paired for Voronoi.
+             pass # Allow pipe method, others might fail or need specific handling.
+    else:
+        raise ValueError(f"Unsupported trajectory shape: {trajectory.shape}")
+
+
+    if method == "voronoi":
+        # kx = REAL(trajectory)
+        # ky = IMAG(trajectory)
+        # coords = STACK(kx, ky, axis=2) // Shape: (num_arms, num_samples, 2)
+        # ...
+        # For simplicity, if Voronoi is too complex for direct translation now,
+        # raise a NotImplementedError or return a simple default.
+        raise NotImplementedError("Voronoi method for density compensation not yet implemented. Consider 'pipe' or a simpler method.")
+
+    elif method == "pipe":
+        # Determine if trajectory is complex or real coordinates
+        if np.iscomplexobj(trajectory_flat): # (N_points,) complex
+            radius = np.abs(trajectory_flat)
+        elif trajectory_flat.ndim == 2 : # (N_points, dims) real
+            radius = np.sqrt(np.sum(trajectory_flat**2, axis=-1))
+        elif trajectory_flat.ndim == 1 and not np.iscomplexobj(trajectory_flat): # (N_points,) real, assume it's already radius
+            radius = trajectory_flat
+        else:
+            raise ValueError(f"Unsupported trajectory format for pipe method: shape {trajectory_flat.shape}, dtype {trajectory_flat.dtype}")
+        
+        density_weights = radius
+        if len(original_shape) > 1 and density_weights.ndim == 1: # Reshape if original was e.g. (num_arms, num_samples)
+            density_weights = density_weights.reshape(original_shape)
+
+    else:
+        raise ValueError(f"Unknown density compensation method: {method}")
+
+    # Optional normalization (pseudocode mentions it)
+    # if np.max(density_weights) > 0:
+    #    density_weights = density_weights / np.max(density_weights)
+    return density_weights
+
+# Example usage (commented out, for testing/illustration if run directly)
+# if __name__ == '__main__':
+    # Create some dummy data
+    # num_coils, Nx, Ny, Nz = 4, 64, 64, 32
+    # coil_imgs_3d = np.random.rand(num_coils, Nx, Ny, Nz) + 1j * np.random.rand(num_coils, Nx, Ny, Nz)
+    # coil_imgs_2d = np.random.rand(num_coils, Nx, Ny) + 1j * np.random.rand(num_coils, Nx, Ny)
+    
+    # sens_maps_3d = np.random.rand(num_coils, Nx, Ny, Nz) + 1j * np.random.rand(num_coils, Nx, Ny, Nz)
+    # sens_maps_2d = np.random.rand(num_coils, Nx, Ny) + 1j * np.random.rand(num_coils, Nx, Ny)
+    
+    # # Normalize sensitivity maps (as they typically are)
+    # sos_3d = np.sqrt(np.sum(np.abs(sens_maps_3d)**2, axis=0))
+    # sens_maps_3d = sens_maps_3d / (sos_3d[np.newaxis,...] + EPSILON)
+    # sos_2d = np.sqrt(np.sum(np.abs(sens_maps_2d)**2, axis=0))
+    # sens_maps_2d = sens_maps_2d / (sos_2d[np.newaxis,...] + EPSILON)
+
+    # print("Testing 2D coil combination:")
+    # try:
+    #     combined_sos_2d = coil_combination_with_phase(coil_imgs_2d, method="sos")
+    #     print(f"SOS 2D output shape: {combined_sos_2d.shape}")
+    #     combined_roemer_2d = coil_combination_with_phase(coil_imgs_2d, method="roemer", sensitivity_maps=sens_maps_2d)
+    #     print(f"Roemer 2D output shape: {combined_roemer_2d.shape}")
+    #     combined_sos_sens_2d = coil_combination_with_phase(coil_imgs_2d, method="sos_sensitivity", sensitivity_maps=sens_maps_2d)
+    #     print(f"SOS_Sensitivity 2D output shape: {combined_sos_sens_2d.shape}")
+    # except Exception as e:
+    #     print(f"Error in 2D combination: {e}")
+
+    # print("\nTesting 3D coil combination:")
+    # try:
+    #     combined_sos_3d = coil_combination_with_phase(coil_imgs_3d, method="sos")
+    #     print(f"SOS 3D output shape: {combined_sos_3d.shape}")
+    #     combined_roemer_3d = coil_combination_with_phase(coil_imgs_3d, method="roemer", sensitivity_maps=sens_maps_3d)
+    #     print(f"Roemer 3D output shape: {combined_roemer_3d.shape}")
+    # except Exception as e:
+    #     print(f"Error in 3D combination: {e}")
+
+    # print("\nTesting phase estimation (2D):")
+    # try:
+    #     phase_maps_lowres_2d = estimate_phase_maps(coil_imgs_2d, method="lowres")
+    #     print(f"Phase maps lowres 2D shape: {phase_maps_lowres_2d.shape}")
+    #     phase_maps_ref_2d = estimate_phase_maps(coil_imgs_2d, method="reference", reference_coil=0)
+    #     print(f"Phase maps reference 2D shape: {phase_maps_ref_2d.shape}")
+    # except Exception as e:
+    #     print(f"Error in phase estimation: {e}")
+
+    # print("\nTesting density compensation:")
+    # try:
+        # traj_complex_1d = np.random.rand(100) + 1j*np.random.rand(100) # (N_points,)
+        # traj_real_2d = np.random.rand(100, 2) # (N_points, 2)
+        # traj_real_3d_arms = np.random.rand(10, 50, 2) # (num_arms, num_samples, 2)
+
+        # dcw_pipe_1 = compute_density_compensation(traj_complex_1d, method="pipe")
+        # print(f"DCW Pipe (complex 1D input) shape: {dcw_pipe_1.shape}")
+        # dcw_pipe_2 = compute_density_compensation(traj_real_2d, method="pipe")
+        # print(f"DCW Pipe (real 2D input) shape: {dcw_pipe_2.shape}")
+        # dcw_pipe_3 = compute_density_compensation(traj_real_3d_arms, method="pipe")
+        # print(f"DCW Pipe (real 3D input) shape: {dcw_pipe_3.shape}, expected {(10,50)}")
+
+        # try:
+        #     compute_density_compensation(traj_real_2d, method="voronoi")
+        # except NotImplementedError as nie:
+        #     print(f"Voronoi DCW: {nie}")
+            
+    # except Exception as e:
+    #     print(f"Error in density compensation: {e}")
+
+    # print("\nTesting sensitivity map estimation (placeholders):")
+    # try:
+    #     num_coils_k, num_arms_k, num_samples_k = 4, 16, 128
+    #     k_data = np.random.randn(num_coils_k, num_arms_k, num_samples_k) + 1j * np.random.randn(num_coils_k, num_arms_k, num_samples_k)
+    #     traj = np.random.randn(num_arms_k, num_samples_k, 2)
+    #     grid_sz = (64,64)
+    #     estimate_sensitivity_maps(k_data, traj, grid_sz, method="lowres")
+    # except NotImplementedError as nie:
+    #     print(f"Sensitivity maps (lowres): {nie}") # Expected due to placeholders
+    # except Exception as e:
+    #     print(f"Error in sensitivity map estimation: {e}")
+
+    # print("\nTesting reconstruct_coil_images (placeholders):")
+    # try:
+    #     reconstruct_coil_images(k_data, traj, grid_sz)
+    # except NotImplementedError as nie:
+    #     print(f"Reconstruct coil images: {nie}") # Expected due to placeholders
+    # except Exception as e:
+    #     print(f"Error in reconstruct_coil_images: {e}")

--- a/tests/test_coil_combination.py
+++ b/tests/test_coil_combination.py
@@ -1,0 +1,392 @@
+import numpy as np
+import pytest
+import scipy.ndimage # For testing smoothing effects indirectly
+
+from reconlib.coil_combination import (
+    coil_combination_with_phase,
+    estimate_phase_maps,
+    estimate_sensitivity_maps,
+    reconstruct_coil_images,
+    compute_density_compensation,
+    EPSILON
+)
+from reconlib.coil_combination import regrid_kspace, filter_low_frequencies # Import placeholders for mocking
+
+# --- Pytest Fixtures for Test Data ---
+
+@pytest.fixture
+def dummy_coil_images_2d():
+    num_coils, Nx, Ny = 4, 32, 32
+    return np.random.rand(num_coils, Nx, Ny) + 1j * np.random.rand(num_coils, Nx, Ny)
+
+@pytest.fixture
+def dummy_coil_images_3d():
+    num_coils, Nx, Ny, Nz = 4, 16, 16, 8
+    return np.random.rand(num_coils, Nx, Ny, Nz) + 1j * np.random.rand(num_coils, Nx, Ny, Nz)
+
+@pytest.fixture
+def dummy_sensitivity_maps_2d(dummy_coil_images_2d):
+    s_maps = np.random.rand(*dummy_coil_images_2d.shape) + 1j * np.random.rand(*dummy_coil_images_2d.shape)
+    sos = np.sqrt(np.sum(np.abs(s_maps)**2, axis=0, keepdims=True))
+    return s_maps / (sos + EPSILON)
+
+@pytest.fixture
+def dummy_sensitivity_maps_3d(dummy_coil_images_3d):
+    s_maps = np.random.rand(*dummy_coil_images_3d.shape) + 1j * np.random.rand(*dummy_coil_images_3d.shape)
+    sos = np.sqrt(np.sum(np.abs(s_maps)**2, axis=0, keepdims=True))
+    return s_maps / (sos + EPSILON)
+
+@pytest.fixture
+def dummy_phase_maps_2d(dummy_coil_images_2d):
+    return np.random.uniform(-np.pi, np.pi, dummy_coil_images_2d.shape)
+
+@pytest.fixture
+def dummy_phase_maps_3d(dummy_coil_images_3d):
+    return np.random.uniform(-np.pi, np.pi, dummy_coil_images_3d.shape)
+
+@pytest.fixture
+def dummy_kspace_data_2d():
+    num_coils, num_arms, num_samples = 4, 16, 128
+    return np.random.randn(num_coils, num_arms, num_samples) + 1j * np.random.randn(num_coils, num_arms, num_samples)
+
+@pytest.fixture
+def dummy_trajectory_2d(dummy_kspace_data_2d):
+    _, num_arms, num_samples = dummy_kspace_data_2d.shape
+    return np.random.randn(num_arms, num_samples, 2) # (num_arms, num_samples, kx_ky_coords)
+
+@pytest.fixture
+def dummy_grid_size_2d():
+    return (32, 32)
+
+@pytest.fixture
+def dummy_kspace_data_flat(): # (num_coils, N_kpoints)
+    num_coils, N_kpoints = 4, 2048
+    return np.random.randn(num_coils, N_kpoints) + 1j * np.random.randn(num_coils, N_kpoints)
+
+@pytest.fixture
+def dummy_trajectory_flat(dummy_kspace_data_flat): # (N_kpoints, dims)
+    _, N_kpoints = dummy_kspace_data_flat.shape
+    return np.random.randn(N_kpoints, 2)
+
+
+# --- Test Classes ---
+
+class TestCoilCombinationWithPhase:
+    @pytest.mark.parametrize("is_3d", [False, True])
+    def test_sos_method(self, is_3d, dummy_coil_images_2d, dummy_coil_images_3d):
+        coil_images = dummy_coil_images_3d if is_3d else dummy_coil_images_2d
+        combined = coil_combination_with_phase(coil_images, method="sos")
+        assert combined.shape == coil_images.shape[1:]
+        assert not np.iscomplexobj(combined)
+        assert np.all(combined >= 0)
+        assert np.max(combined) <= 1.0 + EPSILON # Check normalization
+
+    @pytest.mark.parametrize("is_3d", [False, True])
+    def test_roemer_method(self, is_3d, dummy_coil_images_2d, dummy_coil_images_3d,
+                           dummy_sensitivity_maps_2d, dummy_sensitivity_maps_3d):
+        coil_images = dummy_coil_images_3d if is_3d else dummy_coil_images_2d
+        s_maps = dummy_sensitivity_maps_3d if is_3d else dummy_sensitivity_maps_2d
+        combined = coil_combination_with_phase(coil_images, method="roemer", sensitivity_maps=s_maps)
+        assert combined.shape == coil_images.shape[1:]
+        assert not np.iscomplexobj(combined)
+        assert np.all(combined >= 0)
+        assert np.max(combined) <= 1.0 + EPSILON # Check normalization
+
+    @pytest.mark.parametrize("is_3d", [False, True])
+    def test_sos_sensitivity_method(self, is_3d, dummy_coil_images_2d, dummy_coil_images_3d,
+                                    dummy_sensitivity_maps_2d, dummy_sensitivity_maps_3d):
+        coil_images = dummy_coil_images_3d if is_3d else dummy_coil_images_2d
+        s_maps = dummy_sensitivity_maps_3d if is_3d else dummy_sensitivity_maps_2d
+        combined = coil_combination_with_phase(coil_images, method="sos_sensitivity", sensitivity_maps=s_maps)
+        assert combined.shape == coil_images.shape[1:]
+        assert not np.iscomplexobj(combined)
+        assert np.all(combined >= 0)
+        assert np.max(combined) <= 1.0 + EPSILON
+
+    @pytest.mark.parametrize("is_3d", [False, True])
+    def test_with_phase_maps(self, is_3d, dummy_coil_images_2d, dummy_coil_images_3d,
+                              dummy_phase_maps_2d, dummy_phase_maps_3d):
+        coil_images = dummy_coil_images_3d if is_3d else dummy_coil_images_2d
+        phase_maps = dummy_phase_maps_3d if is_3d else dummy_phase_maps_2d
+        # Test with SoS, as it's simplest to verify phase effect if any (though SoS ignores phase)
+        combined = coil_combination_with_phase(coil_images, method="sos", phase_maps=phase_maps)
+        assert combined.shape == coil_images.shape[1:]
+        # Basic check, phase maps should not break SoS
+        assert np.max(combined) <= 1.0 + EPSILON
+
+    def test_roemer_needs_sens_maps(self, dummy_coil_images_2d):
+        with pytest.raises(ValueError, match="Sensitivity maps required for Roemer combination"):
+            coil_combination_with_phase(dummy_coil_images_2d, method="roemer")
+
+    def test_sos_sensitivity_needs_sens_maps(self, dummy_coil_images_2d):
+        with pytest.raises(ValueError, match="Sensitivity maps required for SoS with sensitivity"):
+            coil_combination_with_phase(dummy_coil_images_2d, method="sos_sensitivity")
+
+    def test_invalid_method(self, dummy_coil_images_2d):
+        with pytest.raises(ValueError, match="Unknown coil combination method"):
+            coil_combination_with_phase(dummy_coil_images_2d, method="invalid_method")
+
+    def test_input_type_errors(self):
+        with pytest.raises(TypeError, match="coil_images must be a NumPy array"):
+            coil_combination_with_phase([1, 2, 3])
+        with pytest.raises(ValueError, match="coil_images must have at least 3 dimensions"):
+            coil_combination_with_phase(np.array([[1,2],[3,4]]))
+
+
+class TestEstimatePhaseMaps:
+    @pytest.mark.parametrize("is_3d", [False, True])
+    def test_lowres_method(self, is_3d, dummy_coil_images_2d, dummy_coil_images_3d):
+        coil_images = dummy_coil_images_3d if is_3d else dummy_coil_images_2d
+        phase_maps = estimate_phase_maps(coil_images, method="lowres")
+        assert phase_maps.shape == coil_images.shape
+        assert np.issubdtype(phase_maps.dtype, np.floating)
+        assert np.all(phase_maps >= -np.pi - EPSILON) and np.all(phase_maps <= np.pi + EPSILON)
+        # Check if smoothing was applied (difficult to check directly without original)
+        # A simple check: variance of phase maps should be lower than variance of raw angle(coil_images)
+        # This is a heuristic and might not always hold robustly but can catch gross errors.
+        raw_phases = np.angle(coil_images)
+        # Ensure smoothing is applied by checking if variance changes.
+        # This requires scipy.ndimage.gaussian_filter to have an effect.
+        # If sigmas are too small, this test might fail. Sigmas are derived from image size.
+        # For a 32x32 image, sigma is ~1.6. For 16x16, ~0.8. These should smooth.
+        if coil_images.shape[1] > 4 and coil_images.shape[2] > 4: # Avoid issues with tiny images
+             assert np.var(phase_maps) < np.var(raw_phases) * 1.5 # Allow some margin
+
+    @pytest.mark.parametrize("is_3d", [False, True])
+    def test_reference_method(self, is_3d, dummy_coil_images_2d, dummy_coil_images_3d):
+        coil_images = dummy_coil_images_3d if is_3d else dummy_coil_images_2d
+        num_coils = coil_images.shape[0]
+        ref_coil_idx = num_coils // 2
+        phase_maps = estimate_phase_maps(coil_images, method="reference", reference_coil=ref_coil_idx)
+        assert phase_maps.shape == coil_images.shape
+        assert np.issubdtype(phase_maps.dtype, np.floating)
+        assert np.all(phase_maps >= -np.pi - EPSILON) and np.all(phase_maps <= np.pi + EPSILON)
+        # The phase of the reference coil relative to itself (after smoothing) should be close to 0
+        # This tests the relative phase calculation and smoothing effect.
+        # Phase of coil_images[ref_coil_idx] - (phase of coil_images[ref_coil_idx] - smoothed_ref_phase)
+        # = smoothed_ref_phase.
+        # The phase_maps[ref_coil_idx] is smoothed (angle(coil_images[ref_coil_idx]) - angle(coil_images[ref_coil_idx])) = 0, then smoothed.
+        # So phase_maps[ref_coil_idx] should be close to zero.
+        assert np.allclose(phase_maps[ref_coil_idx], 0, atol=0.1) # After smoothing, should be near 0
+
+    def test_invalid_method(self, dummy_coil_images_2d):
+        with pytest.raises(ValueError, match="Unknown phase estimation method"):
+            estimate_phase_maps(dummy_coil_images_2d, method="invalid_method")
+
+    def test_invalid_reference_coil(self, dummy_coil_images_2d):
+        with pytest.raises(ValueError, match="reference_coil index .* is out of bounds"):
+            estimate_phase_maps(dummy_coil_images_2d, method="reference", reference_coil=100)
+
+    def test_input_type_errors(self):
+        with pytest.raises(TypeError, match="coil_images must be a NumPy array"):
+            estimate_phase_maps([1,2,3])
+        with pytest.raises(ValueError, match="coil_images must have at least 3 dimensions"):
+            estimate_phase_maps(np.array([[1,2],[3,4]]))
+
+
+class TestEstimateSensitivityMaps:
+    # Mocking placeholder functions for these tests
+    @pytest.fixture(autouse=True)
+    def mock_external_dependencies(self, monkeypatch):
+        # Mock regrid_kspace: needs to return something of shape (grid_size)
+        def mock_regrid(kspace_data, trajectory, grid_size, density_weights=None):
+            # print(f"Mock regrid called with grid_size: {grid_size}")
+            # Ensure grid_size is a tuple of integers
+            if not isinstance(grid_size, tuple) or not all(isinstance(d, int) for d in grid_size):
+                 raise ValueError(f"Mock regrid_kspace expects grid_size to be a tuple of ints, got {grid_size}")
+            return np.random.randn(*grid_size) + 1j * np.random.randn(*grid_size)
+
+        # Mock filter_low_frequencies: needs to return kspace_data (can be same as input for simplicity)
+        def mock_filter_low_freq(kspace_data, trajectory):
+            return kspace_data # Pass-through
+
+        monkeypatch.setattr('reconlib.coil_combination.regrid_kspace', mock_regrid)
+        monkeypatch.setattr('reconlib.coil_combination.filter_low_frequencies', mock_filter_low_freq)
+
+
+    def test_lowres_method(self, dummy_kspace_data_2d, dummy_trajectory_2d, dummy_grid_size_2d):
+        s_maps = estimate_sensitivity_maps(dummy_kspace_data_2d, dummy_trajectory_2d,
+                                           dummy_grid_size_2d, method="lowres")
+        expected_shape = (dummy_kspace_data_2d.shape[0],) + dummy_grid_size_2d
+        assert s_maps.shape == expected_shape
+        assert np.iscomplexobj(s_maps)
+        
+        # Check normalization: sum of squares of magnitudes across coils should be approx 1
+        s_maps_mag_sq = np.abs(s_maps)**2
+        sos_check = np.sum(s_maps_mag_sq, axis=0)
+        assert np.allclose(sos_check, 1.0, atol=1e-5) # Looser tolerance due to mocks/randomness
+
+    def test_espirit_method_raises_not_implemented(self, dummy_kspace_data_2d, dummy_trajectory_2d, dummy_grid_size_2d):
+        with pytest.raises(NotImplementedError, match="ESPIRiT method not yet implemented"):
+            estimate_sensitivity_maps(dummy_kspace_data_2d, dummy_trajectory_2d,
+                                      dummy_grid_size_2d, method="espirit")
+
+    def test_invalid_method(self, dummy_kspace_data_2d, dummy_trajectory_2d, dummy_grid_size_2d):
+        with pytest.raises(ValueError, match="Unknown sensitivity estimation method"):
+            estimate_sensitivity_maps(dummy_kspace_data_2d, dummy_trajectory_2d,
+                                      dummy_grid_size_2d, method="invalid_method")
+    
+    def test_input_type_errors(self, dummy_trajectory_2d, dummy_grid_size_2d):
+        with pytest.raises(TypeError, match="kspace_data must be a complex NumPy array"):
+            estimate_sensitivity_maps(np.random.rand(4,100), dummy_trajectory_2d, dummy_grid_size_2d) # Real data
+        with pytest.raises(ValueError, match="kspace_data must have at least 2 dimensions"):
+            estimate_sensitivity_maps(np.array([1+1j]), dummy_trajectory_2d, dummy_grid_size_2d)
+
+
+class TestReconstructCoilImages:
+    # Mocking placeholder functions for these tests
+    @pytest.fixture(autouse=True)
+    def mock_regrid_and_density(self, monkeypatch):
+        # Mock regrid_kspace
+        def mock_regrid(kspace_data, trajectory, grid_size, density_weights=None):
+            if not isinstance(grid_size, tuple) or not all(isinstance(d, int) for d in grid_size):
+                 raise ValueError(f"Mock regrid_kspace expects grid_size to be a tuple of ints, got {grid_size}")
+            return np.random.randn(*grid_size) + 1j * np.random.randn(*grid_size)
+        
+        # Mock compute_density_compensation
+        def mock_compute_density(trajectory, method="pipe"):
+            # Shape depends on trajectory shape.
+            # If trajectory is (num_arms, num_samples, dims), output (num_arms, num_samples)
+            # If trajectory is (N_kpoints, dims), output (N_kpoints,)
+            if trajectory.ndim == 3: # (num_arms, num_samples, dims)
+                return np.random.rand(trajectory.shape[0], trajectory.shape[1])
+            elif trajectory.ndim == 2: # (N_kpoints, dims)
+                return np.random.rand(trajectory.shape[0])
+            else: # Fallback for other shapes, e.g. complex 1D
+                return np.random.rand(trajectory.shape[0])
+
+
+        monkeypatch.setattr('reconlib.coil_combination.regrid_kspace', mock_regrid)
+        monkeypatch.setattr('reconlib.coil_combination.compute_density_compensation', mock_compute_density)
+
+    def test_basic_reconstruction(self, dummy_kspace_data_2d, dummy_trajectory_2d, dummy_grid_size_2d):
+        coil_images = reconstruct_coil_images(dummy_kspace_data_2d, dummy_trajectory_2d, dummy_grid_size_2d)
+        expected_shape = (dummy_kspace_data_2d.shape[0],) + dummy_grid_size_2d
+        assert coil_images.shape == expected_shape
+        assert np.iscomplexobj(coil_images)
+
+    def test_with_density_weights(self, dummy_kspace_data_flat, dummy_trajectory_flat, dummy_grid_size_2d):
+        # dummy_trajectory_flat is (N_kpoints, 2)
+        # dummy_kspace_data_flat is (num_coils, N_kpoints)
+        # density_weights should be (N_kpoints,)
+        density_weights = np.random.rand(dummy_trajectory_flat.shape[0]) 
+        coil_images = reconstruct_coil_images(dummy_kspace_data_flat, dummy_trajectory_flat,
+                                              dummy_grid_size_2d, density_weights=density_weights)
+        expected_shape = (dummy_kspace_data_flat.shape[0],) + dummy_grid_size_2d
+        assert coil_images.shape == expected_shape
+        assert np.iscomplexobj(coil_images)
+
+    def test_unmocked_regrid_raises_error(self, monkeypatch, dummy_kspace_data_2d, dummy_trajectory_2d, dummy_grid_size_2d):
+        # Restore original regrid_kspace which should be a placeholder
+        monkeypatch.setattr('reconlib.coil_combination.regrid_kspace', regrid_kspace) 
+        # We also need to ensure compute_density_compensation doesn't fail first if it's called
+        # For this test, let's provide density_weights to isolate regrid_kspace
+        density_weights = np.random.rand(dummy_trajectory_2d.shape[0], dummy_trajectory_2d.shape[1])
+
+        with pytest.raises(NotImplementedError, match="regrid_kspace not yet implemented"):
+            reconstruct_coil_images(dummy_kspace_data_2d, dummy_trajectory_2d,
+                                    dummy_grid_size_2d, density_weights=density_weights)
+            
+    def test_input_type_errors(self, dummy_trajectory_2d, dummy_grid_size_2d):
+        with pytest.raises(TypeError, match="kspace_data must be a complex NumPy array"):
+            reconstruct_coil_images(np.random.rand(4,100,10), dummy_trajectory_2d, dummy_grid_size_2d)
+        with pytest.raises(ValueError, match="kspace_data must have at least 2 dimensions"):
+            reconstruct_coil_images(np.array([1+1j]), dummy_trajectory_2d, dummy_grid_size_2d)
+
+
+class TestComputeDensityCompensation:
+    @pytest.mark.parametrize("traj_type", ["complex_flat", "real_2d_flat", "real_3d_arms"])
+    def test_pipe_method(self, traj_type):
+        if traj_type == "complex_flat":
+            # (N_kpoints,) complex
+            trajectory = np.random.rand(100) + 1j * np.random.rand(100)
+            expected_shape = (100,)
+        elif traj_type == "real_2d_flat":
+            # (N_kpoints, dims)
+            trajectory = np.random.rand(100, 2)
+            expected_shape = (100,)
+        elif traj_type == "real_3d_arms":
+            # (num_arms, num_samples, dims)
+            trajectory = np.random.rand(10, 20, 2)
+            expected_shape = (10, 20)
+        else: # real_1d_flat (interpreted as radius)
+            trajectory = np.random.rand(100)
+            expected_shape = (100,)
+
+
+        weights = compute_density_compensation(trajectory, method="pipe")
+        assert weights.shape == expected_shape
+        assert np.issubdtype(weights.dtype, np.floating) # Should be real
+        if traj_type == "complex_flat":
+            assert np.all(weights == np.abs(trajectory))
+        elif "real" in traj_type: # For real coordinate inputs
+            if trajectory.ndim == 1: # Assumed to be radius
+                 assert np.all(weights == trajectory)
+            else: # Calculated radius
+                 radius = np.sqrt(np.sum(trajectory**2, axis=-1))
+                 assert np.allclose(weights, radius)
+
+
+    def test_voronoi_method_raises_not_implemented(self):
+        trajectory = np.random.rand(100, 2)
+        with pytest.raises(NotImplementedError, match="Voronoi method for density compensation not yet implemented"):
+            compute_density_compensation(trajectory, method="voronoi")
+
+    def test_invalid_method(self):
+        trajectory = np.random.rand(100, 2)
+        with pytest.raises(ValueError, match="Unknown density compensation method"):
+            compute_density_compensation(trajectory, method="invalid_method")
+            
+    def test_input_type_errors(self):
+        with pytest.raises(TypeError, match="trajectory must be a NumPy array"):
+            compute_density_compensation([1,2,3])
+
+    def test_pipe_method_1d_real_trajectory(self):
+        # Test specific case: 1D real trajectory (interpreted as radius directly)
+        trajectory = np.random.rand(50) 
+        weights = compute_density_compensation(trajectory, method="pipe")
+        assert weights.shape == trajectory.shape
+        assert np.all(weights == trajectory)
+
+    def test_pipe_method_unsupported_trajectory_format(self):
+        # Example: A 4D trajectory, which is not handled by current logic
+        trajectory = np.random.rand(2,3,4,5)
+        with pytest.raises(ValueError, match="Unsupported trajectory shape"):
+            compute_density_compensation(trajectory, method="pipe")
+
+
+# Helper to check if a module function is a placeholder (raises NotImplementedError)
+def is_placeholder(func, *args, **kwargs):
+    try:
+        func(*args, **kwargs)
+        return False
+    except NotImplementedError:
+        return True
+    except Exception: # Other errors mean it's not just a placeholder
+        return False
+
+# Test if the placeholder functions themselves raise NotImplementedError
+# This is important because other tests might mock them.
+class TestPlaceholdersAreImplementedOrNot:
+    def test_regrid_kspace_placeholder(self):
+        # Provide minimal valid-looking args
+        kspace_data = np.array([1+1j])
+        trajectory = np.array([[0,0]])
+        grid_size = (2,2)
+        assert is_placeholder(regrid_kspace, kspace_data, trajectory, grid_size), \
+            "regrid_kspace is expected to be a placeholder but did not raise NotImplementedError"
+
+    def test_filter_low_frequencies_placeholder(self):
+        kspace_data = np.array([1+1j])
+        trajectory = np.array([[0,0]])
+        assert is_placeholder(filter_low_frequencies, kspace_data, trajectory), \
+            "filter_low_frequencies is expected to be a placeholder but did not raise NotImplementedError"
+
+# Note: Other placeholders like ESPIRiT are tested implicitly when methods using them are called.
+# For example, estimate_sensitivity_maps with method="espirit".
+# compute_voronoi_tessellation and compute_polygon_area are not directly exposed or tested here,
+# but would be if compute_density_compensation(method="voronoi") was implemented using them.
+
+# To run these tests:
+# Ensure reconlib is in PYTHONPATH
+# `pytest tests/test_coil_combination.py`


### PR DESCRIPTION
Adds a new module `reconlib.coil_combination` providing functionality for MRI coil signal combination with optional phase estimation and correction.

The module includes the following key functions:

- `coil_combination_with_phase`: Combines images from multiple coils using Sum-of-Squares (SoS), Roemer's optimal method, or SoS with sensitivity weighting. Includes phase correction capabilities.
- `estimate_phase_maps`: Estimates phase maps for each coil using either a low-resolution filtering approach or by referencing a specific coil. Includes phase smoothing.
- `estimate_sensitivity_maps`: Estimates coil sensitivity maps. Implements a low-resolution image-based method and provides a placeholder for the ESPIRiT method.
- `reconstruct_coil_images`: Reconstructs individual coil images from k-space data. Placeholder for actual regridding logic.
- `compute_density_compensation`: Computes density compensation weights for non-Cartesian trajectories. Implements a "pipe" method (based on k-space radius) and provides a placeholder for Voronoi-based methods.

The implementation is based on the provided pseudocode and uses NumPy for numerical operations and SciPy for tasks like filtering and FFTs. Placeholder functions are included for more complex algorithms (e.g., ESPIRiT, Voronoi tessellation, k-space regridding) that would typically rely on specialized external libraries or more extensive implementations.

A comprehensive suite of unit tests has been added in `tests/test_coil_combination.py` using the pytest framework. These tests cover various methods, edge cases, error handling, and utilize mocking for placeholder dependencies to ensure the implemented logic is validated.